### PR TITLE
feat: shared components - UHeightLimitedText & UTimeline

### DIFF
--- a/src/app/[lang]/design_system/page.tsx
+++ b/src/app/[lang]/design_system/page.tsx
@@ -27,11 +27,36 @@ import EpisodeCard from '@/modules/Podcast/components/EpisodeCard'
 import IndexEpisodeCard from '@/modules/Podcast/components/IndexEpisodeCard'
 import { Box, Grid2 as Grid, Stack, Typography } from '@mui/material'
 import people from '@/modules/People/data'
+import UTimeline, { UTimelineData } from '@/common/components/atoms/UTimeline'
+import UContentCard from '@/common/components/atoms/UContentCard'
+import UHeightLimitedText from '@/common/components/atoms/UHeightLimitedText'
+
 const StyledIndexEpisodeCardList = styled(Stack)(({ theme }) => ({
   borderRadius: '30px',
   backgroundColor: theme.color.orange[900],
   padding: '20px',
 }))
+
+const timelineData: UTimelineData = [
+  {
+    title: 'title1',
+    subtitle: 'subtitle1',
+  },
+  {
+    title: 'title2',
+  },
+  {
+    title: 'title3',
+    subtitle: 'subtitle3',
+  },
+  {
+    title: 'title4',
+  },
+  {
+    title: 'title5',
+    subtitle: 'subtitle5',
+  },
+]
 
 export default function DesignSystemIconsPage() {
   return (
@@ -316,6 +341,20 @@ export default function DesignSystemIconsPage() {
           <PeopleCard people={people} simplified />
         </Grid>
       </Grid>
+
+      <h2>Timeline</h2>
+      <UContentCard>
+        <UTimeline data={timelineData} activeIndex={2} />
+      </UContentCard>
+
+      <h2>Height Limited Text</h2>
+      <Box width={300}>
+        <UHeightLimitedText variant="body" maxLine={3}>
+          Lorem ipsum dolor sit amet consectetur adipisicing elit. Quisquam,
+          Lorem ipsum dolor sit amet consectetur adipisicing elit. Quisquam,
+          Lorem ipsum dolor sit amet consectetur adipisicing elit. Quisquam,
+        </UHeightLimitedText>
+      </Box>
     </div>
   )
 }

--- a/src/app/[lang]/design_system/page.tsx
+++ b/src/app/[lang]/design_system/page.tsx
@@ -347,6 +347,11 @@ export default function DesignSystemIconsPage() {
         <UTimeline data={timelineData} activeIndex={2} />
       </UContentCard>
 
+      <h2>Horizontal Timeline</h2>
+      <UContentCard>
+        <UTimeline data={timelineData} activeIndex={2} isHorizontal />
+      </UContentCard>
+
       <h2>Height Limited Text</h2>
       <Box width={300}>
         <UHeightLimitedText variant="body" maxLine={3}>

--- a/src/common/components/atoms/UHeightLimitedText.tsx
+++ b/src/common/components/atoms/UHeightLimitedText.tsx
@@ -1,0 +1,26 @@
+import { Typography, TypographyProps } from '@mui/material'
+
+type Props = {
+  maxLine: number
+} & TypographyProps
+
+export default function UHeightLimitedText({
+  maxLine,
+  children,
+  ...props
+}: Props) {
+  return (
+    <Typography
+      sx={{
+        display: '-webkit-box',
+        WebkitLineClamp: maxLine,
+        WebkitBoxOrient: 'vertical',
+        overflow: 'hidden',
+        textOverflow: 'ellipsis',
+      }}
+      {...props}
+    >
+      {children}
+    </Typography>
+  )
+}

--- a/src/common/components/atoms/UHeightLimitedText.tsx
+++ b/src/common/components/atoms/UHeightLimitedText.tsx
@@ -17,6 +17,7 @@ export default function UHeightLimitedText({
         WebkitBoxOrient: 'vertical',
         overflow: 'hidden',
         textOverflow: 'ellipsis',
+        ...props.sx,
       }}
       {...props}
     >

--- a/src/common/components/atoms/UTimeline.tsx
+++ b/src/common/components/atoms/UTimeline.tsx
@@ -1,4 +1,3 @@
-import { USTWTheme } from '@/common/lib/mui/theme'
 import {
   Timeline,
   TimelineConnector,
@@ -8,7 +7,21 @@ import {
   timelineItemClasses,
   TimelineSeparator,
 } from '@mui/lab'
-import { Typography, useTheme } from '@mui/material'
+import {
+  Typography,
+  useTheme,
+  Stepper,
+  Step,
+  StepLabel,
+  Box,
+  stepConnectorClasses,
+  StepConnector,
+} from '@mui/material'
+import { styled, USTWTheme } from '@/common/lib/mui/theme'
+
+// Be hardcoded in source code
+const TIMELINE_DOT_MARGIN_PX = 15.5
+const TIMELINE_DOT_WIDTH_PX = 12
 
 type UTimelineItemProps = {
   title: string
@@ -18,6 +31,82 @@ type UTimelineItemProps = {
   isActiveDot: boolean
   isActiveConnector: boolean
 }>
+
+export type UTimelineData = Array<{
+  title: string
+  subtitle?: string
+}>
+
+type UTimelineProps = {
+  data: UTimelineData
+  activeIndex?: number
+  isHorizontal?: boolean
+}
+
+const StyledConnector = styled(StepConnector)(({ theme }) => ({
+  [`&.${stepConnectorClasses.root}`]: {
+    top: 0,
+    left: '-50%',
+    right: '50%',
+  },
+  [`&.${stepConnectorClasses.active}`]: {
+    [`& .${stepConnectorClasses.line}`]: {
+      borderColor: theme.color.purple[100],
+    },
+  },
+  [`&.${stepConnectorClasses.completed}`]: {
+    [`& .${stepConnectorClasses.line}`]: {
+      borderColor: theme.color.purple[100],
+    },
+  },
+  [`&.${stepConnectorClasses.disabled}`]: {
+    [`& .${stepConnectorClasses.line}`]: {
+      borderColor: theme.color.neutral[200],
+    },
+  },
+  [`& .${stepConnectorClasses.line}`]: {
+    borderTopWidth: `${TIMELINE_DOT_WIDTH_PX}px`,
+  },
+}))
+
+function HorizontalTimeline({ data, activeIndex }: UTimelineProps) {
+  const theme = useTheme<USTWTheme>()
+
+  return (
+    <Stepper
+      activeStep={activeIndex}
+      alternativeLabel
+      connector={<StyledConnector />}
+    >
+      {data.map((_, index) => {
+        const isActiveDot = index === activeIndex
+
+        return (
+          <Step key={index}>
+            <StepLabel
+              StepIconComponent={() => (
+                <Box
+                  sx={{
+                    width: TIMELINE_DOT_WIDTH_PX,
+                    height: TIMELINE_DOT_WIDTH_PX,
+                    borderRadius: '50%',
+                    backgroundColor: isActiveDot
+                      ? theme.color.purple[100]
+                      : theme.color.common.black,
+                    outline: isActiveDot
+                      ? `3px solid ${theme.color.common.black}`
+                      : 'none',
+                    zIndex: 1,
+                  }}
+                />
+              )}
+            />
+          </Step>
+        )
+      })}
+    </Stepper>
+  )
+}
 
 function UTimelineItem({
   title,
@@ -75,21 +164,15 @@ function UTimelineItem({
   )
 }
 
-// Be hardcoded in source code
-const TIMELINE_DOT_MARGIN_PX = 15.5
-const TIMELINE_DOT_WIDTH_PX = 12
+export default function UTimeline({
+  data,
+  activeIndex,
+  isHorizontal,
+}: UTimelineProps) {
+  if (isHorizontal) {
+    return <HorizontalTimeline data={data} activeIndex={activeIndex} />
+  }
 
-export type UTimelineData = Array<{
-  title: string
-  subtitle?: string
-}>
-
-type UTimelineProps = {
-  data: UTimelineData
-  activeIndex?: number
-}
-
-export default function UTimeline({ data, activeIndex }: UTimelineProps) {
   return (
     <Timeline
       sx={{

--- a/src/common/components/atoms/UTimeline.tsx
+++ b/src/common/components/atoms/UTimeline.tsx
@@ -1,0 +1,124 @@
+import { USTWTheme } from '@/common/lib/mui/theme'
+import {
+  Timeline,
+  TimelineConnector,
+  TimelineContent,
+  TimelineDot,
+  TimelineItem,
+  timelineItemClasses,
+  TimelineSeparator,
+} from '@mui/lab'
+import { Typography, useTheme } from '@mui/material'
+
+type UTimelineItemProps = {
+  title: string
+} & Partial<{
+  subtitle: string
+  isLast: boolean
+  isActiveDot: boolean
+  isActiveConnector: boolean
+}>
+
+function UTimelineItem({
+  title,
+  subtitle,
+  isLast,
+  isActiveDot,
+  isActiveConnector,
+}: UTimelineItemProps) {
+  const theme = useTheme<USTWTheme>()
+
+  return (
+    <TimelineItem sx={{ minHeight: 'unset' }}>
+      <TimelineSeparator>
+        <TimelineDot
+          sx={{
+            backgroundColor: isActiveDot
+              ? theme.color.purple[100]
+              : theme.color.common.black,
+            outline: isActiveDot
+              ? `3px solid ${theme.color.common.black}`
+              : 'none',
+          }}
+        />
+        {!isLast && (
+          <TimelineConnector
+            sx={{
+              backgroundColor: isActiveConnector
+                ? theme.color.purple[100]
+                : theme.color.neutral[200],
+            }}
+          />
+        )}
+      </TimelineSeparator>
+      <TimelineContent>
+        <Typography
+          variant={isActiveDot ? 'articleH4' : 'buttonS'}
+          {...(isActiveDot && {
+            lineHeight: 1.2,
+          })}
+          sx={{
+            color: isActiveDot
+              ? theme.color.common.black
+              : theme.color.grey[500],
+          }}
+        >
+          {title}
+        </Typography>
+        {subtitle && (
+          <Typography variant="bodyS" sx={{ color: theme.color.neutral[500] }}>
+            {subtitle}
+          </Typography>
+        )}
+      </TimelineContent>
+    </TimelineItem>
+  )
+}
+
+// Be hardcoded in source code
+const TIMELINE_DOT_MARGIN_PX = 15.5
+const TIMELINE_DOT_WIDTH_PX = 12
+
+export type UTimelineData = Array<{
+  title: string
+  subtitle?: string
+}>
+
+type UTimelineProps = {
+  data: UTimelineData
+  activeIndex?: number
+}
+
+export default function UTimeline({ data, activeIndex }: UTimelineProps) {
+  return (
+    <Timeline
+      sx={{
+        padding: 0,
+        margin: 0,
+        [`& .${timelineItemClasses.root}:before`]: {
+          flex: 0,
+          padding: 0,
+        },
+        [`& .MuiTimelineConnector-root`]: {
+          margin: `-${TIMELINE_DOT_MARGIN_PX + TIMELINE_DOT_WIDTH_PX / 2}px 0`,
+          borderRadius: '10px',
+          width: `${TIMELINE_DOT_WIDTH_PX}px`,
+        },
+        [`& .MuiTimelineDot-root`]: {
+          zIndex: 1,
+        },
+      }}
+    >
+      {data.map((d, index) => (
+        <UTimelineItem
+          key={index}
+          title={d.title}
+          subtitle={d.subtitle}
+          isLast={index === data.length - 1}
+          isActiveDot={index === activeIndex}
+          isActiveConnector={!!activeIndex && index < activeIndex}
+        />
+      ))}
+    </Timeline>
+  )
+}


### PR DESCRIPTION
## Summary

把兩個共用元件抽出來：

Timeline
<img width="267" alt="截圖 2024-09-17 下午5 45 26" src="https://github.com/user-attachments/assets/72adc8e4-e405-4ff8-ba8b-0744dd7cd514">

Horizontal Timeline
<img width="541" alt="截圖 2024-09-17 晚上8 27 29" src="https://github.com/user-attachments/assets/674b0b86-7c37-4b88-bf47-ea1ff183fede">

有高度限制的文字，避免卡片爆版
<img width="476" alt="截圖 2024-09-17 下午5 46 02" src="https://github.com/user-attachments/assets/8cf0fe06-e7b7-45c3-8f80-5e15fb14553e">

## Test Plan
![截圖 2024-09-17 晚上8 25 25](https://github.com/user-attachments/assets/f85e24ae-465e-467e-9b47-3bf94306e5be)
