### PR TITLE
feat: shared Tag components

### DIFF
--- a/src/app/[lang]/design_system/page.tsx
+++ b/src/app/[lang]/design_system/page.tsx
@@ -6,7 +6,7 @@ import UIconButton from '@/common/components/atoms/UIconButton'
 import ULinkText from '@/common/components/atoms/ULinkText'
 import UPagination from '@/common/components/atoms/UPagination'
 import UPoliticalPartyIcon from '@/common/components/atoms/UPoliticalPartyIcon'
-import { styled } from '@/common/lib/mui/theme'
+import { styled, USTWTheme } from '@/common/lib/mui/theme'
 import {
   BookmarkIcon,
   FacebookIcon,
@@ -25,11 +25,14 @@ import {
 import PeopleCard from '@/modules/People/components/PeopleCard'
 import EpisodeCard from '@/modules/Podcast/components/EpisodeCard'
 import IndexEpisodeCard from '@/modules/Podcast/components/IndexEpisodeCard'
-import { Box, Grid2 as Grid, Stack, Typography } from '@mui/material'
+import { Box, Grid2 as Grid, Stack, Typography, useTheme } from '@mui/material'
 import people from '@/modules/People/data'
 import UTimeline, { UTimelineData } from '@/common/components/atoms/UTimeline'
 import UContentCard from '@/common/components/atoms/UContentCard'
 import UHeightLimitedText from '@/common/components/atoms/UHeightLimitedText'
+import UHStack from '@/common/components/atoms/UHStack'
+import UCategoryTag from '@/common/components/atoms/UCategoryTag'
+import UHashTag from '@/common/components/atoms/UHashTag'
 
 const StyledIndexEpisodeCardList = styled(Stack)(({ theme }) => ({
   borderRadius: '30px',
@@ -59,6 +62,8 @@ const timelineData: UTimelineData = [
 ]
 
 export default function DesignSystemIconsPage() {
+  const theme = useTheme<USTWTheme>()
+
   return (
     <div>
       <h1>Design System Icons</h1>
@@ -269,7 +274,13 @@ export default function DesignSystemIconsPage() {
       </Stack>
       <h2>Pagination</h2>
       <Box display="flex" p={2} gap={2}>
-        <UPagination count={10} page={1} onChange={() => {}} />
+        <UPagination
+          count={10}
+          page={1}
+          onChange={() => {
+            console.log('changed')
+          }}
+        />
       </Box>
       <h2>People Card</h2>
       <Grid container spacing={2}>
@@ -360,6 +371,98 @@ export default function DesignSystemIconsPage() {
           Lorem ipsum dolor sit amet consectetur adipisicing elit. Quisquam,
         </UHeightLimitedText>
       </Box>
+
+      <h2>UCategoryTag</h2>
+      <UContentCard>
+        <UHStack gap="6px">
+          {['Environment', 'Energy', 'Technology', 'Security'].map(
+            (tag, index) => (
+              <UCategoryTag
+                key={index}
+                value={tag}
+                onClick={() => {
+                  console.log('clicked')
+                }}
+              />
+            )
+          )}
+        </UHStack>
+
+        <UHStack gap="6px" my={2}>
+          {['House', 'Senate'].map((tag, index) => (
+            <UCategoryTag
+              key={index}
+              value={tag}
+              containerProps={{
+                sx: {
+                  backgroundColor: `${theme.color.purple[100]}80`, // 50% opacity
+                },
+              }}
+              textProps={{
+                variant: 'buttonS',
+              }}
+            />
+          ))}
+        </UHStack>
+
+        <UHStack gap="6px" my={2}>
+          <UCategoryTag
+            value="Official"
+            containerProps={{
+              sx: {
+                backgroundColor: theme.color.tyrian[50],
+                borderRadius: '6px',
+                padding: theme.spacing(0.5, 1),
+              },
+            }}
+          />
+          <UCategoryTag
+            value="Expert"
+            containerProps={{
+              sx: {
+                backgroundColor: theme.color.green[100],
+                borderRadius: '6px',
+                padding: theme.spacing(0.5, 1),
+              },
+            }}
+          />
+          <UCategoryTag
+            value="Other"
+            containerProps={{
+              sx: {
+                backgroundColor: theme.color.neutral[300],
+                borderRadius: '6px',
+                padding: theme.spacing(0.5, 1),
+              },
+            }}
+          />
+        </UHStack>
+      </UContentCard>
+
+      <h2>UHashTag</h2>
+      <UContentCard>
+        <UHStack gap="6px" my={2} flexWrap="wrap">
+          {['NATO', 'EU', 'Cybersecurity'].map((tag, index) => (
+            <UHashTag key={index} value={tag} />
+          ))}
+        </UHStack>
+        <UHStack gap="6px" my={2} flexWrap="wrap">
+          {['Semiconductor', 'Humanitarian', 'Aid'].map((tag, index) => (
+            <UHashTag
+              key={index}
+              value={tag}
+              containerProps={{
+                sx: {
+                  backgroundColor: 'transparent',
+                },
+              }}
+              onClick={() => {
+                console.log('clicked')
+              }}
+            />
+          ))}
+        </UHStack>
+      </UContentCard>
     </div>
   )
 }

--- a/src/common/components/atoms/UCategoryTag.tsx
+++ b/src/common/components/atoms/UCategoryTag.tsx
@@ -1,0 +1,46 @@
+'use client'
+
+import { styled } from '@/common/lib/mui/theme'
+import { Stack, StackProps, Typography, TypographyProps } from '@mui/material'
+import { ReactNode } from 'react'
+
+const StyledTagContainer = styled(Stack)(({ theme }) => ({
+  padding: theme.spacing(0.5, 2),
+  borderRadius: '5px',
+  backgroundColor: theme.color.indigo[50],
+}))
+
+type UCategoryTagProps = {
+  value?: string
+  renderValue?: ReactNode
+  containerProps?: StackProps
+  textProps?: TypographyProps
+  onClick?: () => void
+}
+
+export default function UCategoryTag({
+  value,
+  renderValue,
+  containerProps,
+  textProps,
+  onClick,
+}: UCategoryTagProps) {
+  const { sx: containerSx, ...restContainerProps } = containerProps ?? {}
+
+  return (
+    <StyledTagContainer
+      onClick={onClick}
+      sx={{
+        cursor: onClick ? 'pointer' : 'default',
+        ...containerSx,
+      }}
+      {...restContainerProps}
+    >
+      {renderValue ?? (
+        <Typography variant="buttonXS" {...textProps}>
+          {value}
+        </Typography>
+      )}
+    </StyledTagContainer>
+  )
+}

--- a/src/common/components/atoms/UHashTag.tsx
+++ b/src/common/components/atoms/UHashTag.tsx
@@ -1,0 +1,70 @@
+'use client'
+
+import UCategoryTag from '@/common/components/atoms/UCategoryTag'
+import { styled, USTWTheme } from '@/common/lib/mui/theme'
+import {
+  StackProps,
+  Typography,
+  TypographyProps,
+  useTheme,
+} from '@mui/material'
+
+const StyledHashTag = styled(Typography)(({ theme }) => ({
+  color: theme.color.neutral[500],
+}))
+
+const StyledTagText = styled(Typography)(({ theme }) => ({
+  color: theme.color.common.black,
+}))
+
+type UHashTagProps = {
+  value: string
+  containerProps?: StackProps
+  textProps?: TypographyProps
+  hashTagProps?: TypographyProps
+  onClick?: () => void
+}
+
+export default function UHashTag({
+  value,
+  containerProps,
+  textProps,
+  hashTagProps,
+  onClick,
+}: UHashTagProps) {
+  const theme = useTheme<USTWTheme>()
+
+  const { sx: containerSx, ...restContainerProps } = containerProps ?? {}
+
+  return (
+    <UCategoryTag
+      onClick={onClick}
+      containerProps={{
+        borderRadius: '5px',
+        border: `1px solid ${theme.color.grey[1400]}`,
+        direction: 'row',
+        spacing: 0.5,
+        alignItems: 'center',
+        justifyContent: 'center',
+        sx: {
+          px: '9px',
+          py: '6px',
+          backgroundColor: theme.color.grey[100],
+          cursor: onClick ? 'pointer' : 'default',
+          ...containerSx,
+        },
+        ...restContainerProps,
+      }}
+      renderValue={
+        <>
+          <StyledHashTag variant="buttonXXS" {...hashTagProps}>
+            #
+          </StyledHashTag>
+          <StyledTagText variant="buttonXXS" {...textProps}>
+            {value}
+          </StyledTagText>
+        </>
+      }
+    />
+  )
+}

--- a/src/common/components/atoms/UHeightLimitedText.tsx
+++ b/src/common/components/atoms/UHeightLimitedText.tsx
@@ -7,6 +7,7 @@ type Props = {
 export default function UHeightLimitedText({
   maxLine,
   children,
+  sx,
   ...props
 }: Props) {
   return (
@@ -17,7 +18,7 @@ export default function UHeightLimitedText({
         WebkitBoxOrient: 'vertical',
         overflow: 'hidden',
         textOverflow: 'ellipsis',
-        ...props.sx,
+        ...sx,
       }}
       {...props}
     >


### PR DESCRIPTION
## Summary
把 Bill, People, KT media, Opinion 都有出現的 tag 元件獨立出來，考慮到可能需要的功能或樣式不同，拆分成 UCategoryTag 和 UHashTag

<img width="253" alt="截圖 2024-09-21 下午2 50 40" src="https://github.com/user-attachments/assets/b3eefad8-e26f-47ff-a618-d5e2909171bf">
<img width="382" alt="截圖 2024-09-21 下午2 56 21" src="https://github.com/user-attachments/assets/2da59d84-9dac-46db-b73b-e025ad88322b">
<img width="690" alt="截圖 2024-09-21 下午3 17 59" src="https://github.com/user-attachments/assets/06650bcc-e1ee-418c-80e9-147c98023a95">
<img width="387" alt="截圖 2024-09-21 下午2 56 10" src="https://github.com/user-attachments/assets/68edd5af-22ca-4978-b321-e2fd885a09af">

## Test Plan

https://github.com/user-attachments/assets/799cbcf5-f818-45f8-a36b-83ae06ad22ab
