### PR TITLE
Navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,10 @@ feature branch 會以 `Squash` 的方式合併到 `develop` 分支。
 
 透過 `yarn i18n` 指令會從 Content Management System 抓取語言檔案，並放置於 `src/common/lib/i18n/locales` 目錄下。
 
+### 頁面跳轉
+
+凡要進行頁面跳轉，請至 `src/routes.ts` 中定義，並使用 `ROUTES` 物件拿取連結，避免於程式碼中寫死字串，以防路由更名。
+
 ---
 
 ### Dependencies

--- a/src/common/components/elements/Footer/useLinks.tsx
+++ b/src/common/components/elements/Footer/useLinks.tsx
@@ -7,6 +7,7 @@ import {
   YoutubeIcon,
   MailIcon,
 } from '@/common/styles/assets/Icons'
+import { ROUTES } from '@/routes'
 import type React from 'react'
 
 type SocialLinkItem = {
@@ -67,47 +68,47 @@ export default function useLinks() {
         {
           type: 'subLink',
           title: 'Our Mission',
-          url: '/#',
+          url: ROUTES.HOME,
         },
         {
           type: 'subLink',
           title: 'Our Footprints',
-          url: '/#',
+          url: ROUTES.HOME,
         },
         {
           type: 'subLink',
           title: 'Our Ｍember',
-          url: '/#',
+          url: ROUTES.HOME,
         },
         {
           type: 'subLink',
           title: 'Our Newsroom',
-          url: '/#',
+          url: ROUTES.HOME,
         },
         {
           type: 'subLink',
           title: 'Article',
-          url: '/#',
+          url: ROUTES.OPINION,
         },
         {
           type: 'subLink',
           title: 'Events',
-          url: '/#',
+          url: ROUTES.HOME,
         },
         {
           type: 'subLink',
           title: 'Ketagalan Media',
-          url: '/#',
+          url: ROUTES.HOME,
         },
         {
           type: 'subLink',
           title: 'Articles',
-          url: '/#',
+          url: ROUTES.OPINION,
         },
         {
           type: 'subLink',
           title: 'About',
-          url: '/#',
+          url: ROUTES.HOME,
         },
       ],
     },
@@ -118,12 +119,12 @@ export default function useLinks() {
         {
           type: 'subLink',
           title: 'Bills',
-          url: '/#',
+          url: ROUTES.BILL,
         },
         {
           type: 'subLink',
           title: 'People',
-          url: '/#',
+          url: ROUTES.PEOPLE,
         },
       ],
     },
@@ -134,17 +135,17 @@ export default function useLinks() {
         {
           type: 'subLink',
           title: '觀測站底加辣',
-          url: '/#',
+          url: ROUTES.HOME,
         },
         {
           type: 'subLink',
           title: '觀測站予你知',
-          url: '/#',
+          url: ROUTES.HOME,
         },
         {
           type: 'subLink',
           title: '觀測站讀書會',
-          url: '/#',
+          url: ROUTES.HOME,
         },
       ],
     },

--- a/src/common/components/elements/Header/index.tsx
+++ b/src/common/components/elements/Header/index.tsx
@@ -13,6 +13,7 @@ import React, { useRef, useState } from 'react'
 import useNavItems, { HeaderNavItem } from './useNavItems'
 import SearchBar from '@/modules/Search/components/SearchBar'
 import { ProfileIcon, SearchIcon } from '@/common/styles/assets/Icons'
+import { ROUTES } from '@/routes'
 
 interface HeaderProps {
   className?: string
@@ -266,7 +267,7 @@ const Header = ({ className, onProfileClick, onSearchClick }: HeaderProps) => {
               >
                 <SearchIcon />
               </UIconButton>
-              <Link href="/#">
+              <Link href={ROUTES.HOME}>
                 <UButton
                   className="donation-button"
                   variant="contained"

--- a/src/common/components/elements/Header/index.tsx
+++ b/src/common/components/elements/Header/index.tsx
@@ -14,6 +14,7 @@ import useNavItems, { HeaderNavItem } from './useNavItems'
 import SearchBar from '@/modules/Search/components/SearchBar'
 import { ProfileIcon, SearchIcon } from '@/common/styles/assets/Icons'
 import { ROUTES } from '@/routes'
+import { useRouter } from 'next/navigation'
 
 interface HeaderProps {
   className?: string
@@ -128,6 +129,7 @@ const StyledNavMenu = styled(Menu)(({ theme }) => ({
 }))
 
 const Header = ({ className, onProfileClick, onSearchClick }: HeaderProps) => {
+  const router = useRouter()
   const { navItems } = useNavItems()
   const [menuOpenNavItem, setMenuOpenNavItem] = useState<HeaderNavItem | null>(
     null
@@ -171,7 +173,15 @@ const Header = ({ className, onProfileClick, onSearchClick }: HeaderProps) => {
         gap={2}
       >
         {/** 左側 */}
-        <Box display="flex" alignItems="center" gap={1}>
+        <Box
+          display="flex"
+          alignItems="center"
+          gap={1}
+          sx={{ cursor: 'pointer' }}
+          onClick={() => {
+            router.push(ROUTES.HOME)
+          }}
+        >
           <ULogo size="small" />
           <Typography fontWeight={700}>USTW</Typography>
         </Box>

--- a/src/common/components/elements/Header/useNavItems.tsx
+++ b/src/common/components/elements/Header/useNavItems.tsx
@@ -1,3 +1,4 @@
+import { ROUTES } from '@/routes'
 import { useMemo } from 'react'
 
 export type HeaderNavItem =
@@ -27,13 +28,13 @@ export default function useNavItems() {
             id: 'discover-bill',
             type: 'link',
             title: 'Bill',
-            href: '/#',
+            href: ROUTES.BILL,
           },
           {
             id: 'discover-people',
             type: 'link',
             title: 'People',
-            href: '/#',
+            href: ROUTES.PEOPLE,
           },
         ],
       },
@@ -41,13 +42,13 @@ export default function useNavItems() {
         id: 'articles',
         type: 'link',
         title: 'Articles',
-        href: '/#',
+        href: ROUTES.OPINION,
       },
       {
         id: 'ketagalan-media',
         type: 'link',
         title: 'Ketagalan Media',
-        href: '/#',
+        href: ROUTES.HOME,
       },
       {
         id: 'podcasts',
@@ -58,19 +59,19 @@ export default function useNavItems() {
             id: 'podcasts-1',
             type: 'link',
             title: '觀測站底加辣',
-            href: '/#',
+            href: ROUTES.HOME,
           },
           {
             id: 'podcasts-2',
             type: 'link',
             title: '觀測站予你知',
-            href: '/#',
+            href: ROUTES.HOME,
           },
           {
             id: 'podcasts-3',
             type: 'link',
             title: '觀測站讀書會',
-            href: '/#',
+            href: ROUTES.HOME,
           },
         ],
       },
@@ -78,7 +79,7 @@ export default function useNavItems() {
         id: 'events',
         type: 'link',
         title: 'Events',
-        href: '/#',
+        href: ROUTES.HOME,
       },
       {
         id: 'about',
@@ -89,25 +90,25 @@ export default function useNavItems() {
             id: 'about-mission',
             type: 'link',
             title: 'Mission',
-            href: '/#',
+            href: ROUTES.HOME,
           },
           {
             id: 'about-footprints',
             type: 'link',
             title: 'Footprints',
-            href: '/#',
+            href: ROUTES.HOME,
           },
           {
             id: 'about-data',
             type: 'link',
             title: 'Data',
-            href: '/#',
+            href: ROUTES.HOME,
           },
           {
             id: 'about-newsroom',
             type: 'link',
             title: 'Newsroom',
-            href: '/#',
+            href: ROUTES.HOME,
           },
         ],
       },

--- a/src/common/components/elements/IndexKvCards/index.tsx
+++ b/src/common/components/elements/IndexKvCards/index.tsx
@@ -3,6 +3,7 @@
 import UFullWidthBackgroundBox from '@/common/components/atoms/UFullWidthBackgroundBox'
 import Carousel from '@/common/components/elements/Carousel'
 import IndexKvCard from '@/common/components/elements/IndexKvCard'
+import { ROUTES } from '@/routes'
 import { Container } from '@mui/material'
 
 const IndexKVCards = () => {
@@ -15,21 +16,21 @@ const IndexKVCards = () => {
             title="快訊：美國政府宣布提供台灣 8000 萬美元外國軍事融資"
             description="美國時間8/30日，美聯社報導美國政府已正式通知國會，將向台灣提供8000萬美元「無償軍事援助」。去年底通過的2023財政年度國防授權法案（NDAA FY2023）中有一項「台灣增強韌性法案」（Taiwan Enhanced Resilience Act），授權美國國務院從2023年至2027年期間，每年提供台灣高達20億美元的軍援...美國時間8/30日，美聯社報導美國政府已正式通知國會，將向台灣提供8000萬美元「無償軍事援助」。去年底通過的2023財政年度國防授權法案（NDAA FY2023）中有一項「台灣增強韌性法案」（Taiwan Enhanced Resilience Act），授權美國國務院從2023年至2027年期間，每年提供台灣高達20億美元的軍援..."
             image="/assets/category1.jpg"
-            href="https://via.placeholder.com"
+            href={ROUTES.BILL}
           />
           <IndexKvCard
             tags={['#1', '#2', '#3']}
             title="快訊：美國政府宣布提供台灣 8000 萬美元外國軍事融資"
             description="美國時間8/30日，美聯社報導美國政府已正式通知國會，將向台灣提供8000萬美元「無償軍事援助」。去年底通過的2023財政年度國防授權法案（NDAA FY2023）中有一項「台灣增強韌性法案」（Taiwan Enhanced Resilience Act），授權美國國務院從2023年至2027年期間，每年提供台灣高達20億美元的軍援...美國時間8/30日，美聯社報導美國政府已正式通知國會，將向台灣提供8000萬美元「無償軍事援助」。去年底通過的2023財政年度國防授權法案（NDAA FY2023）中有一項「台灣增強韌性法案」（Taiwan Enhanced Resilience Act），授權美國國務院從2023年至2027年期間，每年提供台灣高達20億美元的軍援..."
             image="/assets/category1.jpg"
-            href="https://via.placeholder.com"
+            href={ROUTES.BILL}
           />
           <IndexKvCard
             tags={['#1', '#2', '#3']}
             title="快訊：美國政府宣布提供台灣 8000 萬美元外國軍事融資"
             description="美國時間8/30日，美聯社報導美國政府已正式通知國會，將向台灣提供8000萬美元「無償軍事援助」。去年底通過的2023財政年度國防授權法案（NDAA FY2023）中有一項「台灣增強韌性法案」（Taiwan Enhanced Resilience Act），授權美國國務院從2023年至2027年期間，每年提供台灣高達20億美元的軍援...美國時間8/30日，美聯社報導美國政府已正式通知國會，將向台灣提供8000萬美元「無償軍事援助」。去年底通過的2023財政年度國防授權法案（NDAA FY2023）中有一項「台灣增強韌性法案」（Taiwan Enhanced Resilience Act），授權美國國務院從2023年至2027年期間，每年提供台灣高達20億美元的軍援..."
             image="/assets/category1.jpg"
-            href="https://via.placeholder.com"
+            href={ROUTES.BILL}
           />
         </Carousel>
       </Container>

--- a/src/modules/Bill/classes/Bill.ts
+++ b/src/modules/Bill/classes/Bill.ts
@@ -2,6 +2,7 @@ import { BillStatusEnum } from '@/modules/Bill/enums/BillStatus'
 import { ChamberEnum } from '@/common/enums/Chamber'
 import { People } from '@/modules/People/classes/People'
 import { isArray, isString } from 'lodash-es'
+import { ROUTES } from '@/routes'
 
 interface BillAction {
   date: string
@@ -65,7 +66,7 @@ export class Bill {
   }
 
   get link() {
-    return `/bill/${this.id}`
+    return `${ROUTES.BILL}/${this.id}`
   }
 
   get introducedDate() {

--- a/src/modules/Bill/components/BillLanding/BillListSection.tsx
+++ b/src/modules/Bill/components/BillLanding/BillListSection.tsx
@@ -6,6 +6,7 @@ import LandingSectionWrapper from '@/common/components/elements/Landing/LandingS
 import SectionTitleWithLink from '@/common/components/elements/Landing/SectionTitleWithLink'
 import BillCardCarousel from '@/modules/Bill/components/BillCardCarousel'
 import { Stack } from '@mui/material'
+import { ROUTES } from '@/routes'
 
 const BillListSection = () => {
   const theme = useTheme<USTWTheme>()
@@ -19,12 +20,12 @@ const BillListSection = () => {
       }}
     >
       <Stack gap={theme.spacing(7.5)}>
-        <SectionTitleWithLink title="Latest Bills" link="/bill-list" />
+        <SectionTitleWithLink title="Latest Bills" link={ROUTES.BILL_LIST} />
         <BillCardCarousel simplified />
       </Stack>
 
       <Stack gap={theme.spacing(7.5)}>
-        <SectionTitleWithLink title="Popular Bills" link="/bill-list" />
+        <SectionTitleWithLink title="Popular Bills" link={ROUTES.BILL_LIST} />
         <BillCardCarousel simplified />
       </Stack>
     </LandingSectionWrapper>

--- a/src/modules/Bill/components/SingleBill/BillListSection.tsx
+++ b/src/modules/Bill/components/SingleBill/BillListSection.tsx
@@ -6,6 +6,7 @@ import LandingSectionWrapper from '@/common/components/elements/Landing/LandingS
 import SectionTitleWithLink from '@/common/components/elements/Landing/SectionTitleWithLink'
 import BillCardCarousel from '@/modules/Bill/components/BillCardCarousel'
 import { Stack } from '@mui/material'
+import { ROUTES } from '@/routes'
 
 const BillListSection = () => {
   const theme = useTheme<USTWTheme>()
@@ -19,7 +20,7 @@ const BillListSection = () => {
       }}
     >
       <Stack gap={theme.spacing(7.5)}>
-        <SectionTitleWithLink title="Related Bills" link="/bill-list" />
+        <SectionTitleWithLink title="Related Bills" link={ROUTES.BILL_LIST} />
         <BillCardCarousel />
       </Stack>
     </LandingSectionWrapper>

--- a/src/modules/LandingPage/components/BillSection.tsx
+++ b/src/modules/LandingPage/components/BillSection.tsx
@@ -4,11 +4,12 @@ import { BILL_DATA_MOCK } from '@/modules/Bill/data'
 import { Stack } from '@mui/material'
 import SectionTitleWithLink from '@/common/components/elements/Landing/SectionTitleWithLink'
 import IndexBillCardList from '@/modules/Bill/components/IndexBillCard/IndexBillCardList'
+import { ROUTES } from '@/routes'
 
 const BillSection = () => {
   return (
     <Stack py={10} gap={7.5}>
-      <SectionTitleWithLink title="Bills" link="/bill" />
+      <SectionTitleWithLink title="Bills" link={ROUTES.BILL} />
       <IndexBillCardList billData={BILL_DATA_MOCK} />
     </Stack>
   )

--- a/src/modules/Opinion/components/OpinionNavbar.tsx
+++ b/src/modules/Opinion/components/OpinionNavbar.tsx
@@ -2,6 +2,7 @@
 
 import UHStack from '@/common/components/atoms/UHStack'
 import { USTWTheme } from '@/common/lib/mui/theme'
+import { ROUTES } from '@/routes'
 import { Box, Typography, useTheme } from '@mui/material'
 import Link from 'next/link'
 import { useMemo } from 'react'
@@ -18,27 +19,27 @@ const OpinionNavbar = ({ activeId }: OpinionNavbarProps) => {
       {
         id: 'military',
         label: '軍事國防',
-        href: '/opinion/search/military',
+        href: `${ROUTES.OPINION}/search/military`,
       },
       {
         id: 'foreign',
         label: '外交貿易',
-        href: '/opinion/search/foreign',
+        href: `${ROUTES.OPINION}/search/foreign`,
       },
       {
         id: 'cross-strait',
         label: '兩岸議題',
-        href: '/opinion/search/cross-strait',
+        href: `${ROUTES.OPINION}/search/cross-strait`,
       },
       {
         id: 'election',
         label: '行政選舉',
-        href: '/opinion/search/election',
+        href: `${ROUTES.OPINION}/search/election`,
       },
       {
         id: 'us-law',
         label: '美國法案',
-        href: '/opinion/search/us-law',
+        href: `${ROUTES.OPINION}/search/us-law`,
       },
     ],
     []

--- a/src/modules/People/classes/People.ts
+++ b/src/modules/People/classes/People.ts
@@ -1,6 +1,7 @@
 import { Congress } from '@/common/classes/Congress'
 import { Party } from '@/common/enums/Party'
 import { PeoplePosition } from '@/modules/People/enums/PeoplePosition'
+import { ROUTES } from '@/routes'
 import dayjs, { Dayjs } from 'dayjs'
 import { isArray, isString } from 'lodash-es'
 
@@ -103,7 +104,7 @@ export class People {
   }
 
   get link() {
-    return `/people/${this.id}`
+    return `${ROUTES.PEOPLE}/${this.id}`
   }
 
   static TransformPartyExperience(partyExperience: Array<PartyExperienceArgs>) {

--- a/src/modules/Search/classes/SearchResult.ts
+++ b/src/modules/Search/classes/SearchResult.ts
@@ -1,5 +1,6 @@
 import { isString } from 'lodash-es'
 import { SearchResultResponse } from '../types/SearchResultResponse'
+import { ROUTES } from '@/routes'
 
 export default class SearchResult {
   /** 搜尋結果 */
@@ -12,6 +13,6 @@ export default class SearchResult {
   }
 
   get href() {
-    return `/search/${this.value}`
+    return `${ROUTES.SEARCH}/${this.value}`
   }
 }

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -1,0 +1,8 @@
+export const ROUTES = {
+  HOME: '/',
+  BILL: '/bill',
+  BILL_LIST: '/bill-list',
+  PEOPLE: '/people',
+  OPINION: '/opinion',
+  SEARCH: '/search',
+}


### PR DESCRIPTION
## Summary

1. 定義 `ROUTES` 物件，凡要進行頁面跳轉，皆從 `ROUTES` 拿取連結，避免於程式碼中寫死字串，以防路由更名。
2. 補上 header & footer 的連結

## Test Plan

https://github.com/user-attachments/assets/0a9744fb-9fe9-4126-9e86-889e121ce375

