### PR TITLE
feat: UCardInfo

### DIFF
--- a/src/common/components/atoms/UCardInfo.tsx
+++ b/src/common/components/atoms/UCardInfo.tsx
@@ -1,0 +1,38 @@
+'use client'
+
+import ErrorOutlineOutlinedIcon from '@mui/icons-material/ErrorOutlineOutlined'
+import {
+  IconButton,
+  SvgIconProps,
+  Tooltip,
+  TooltipProps,
+  useTheme,
+} from '@mui/material'
+import { USTWTheme } from '@/common/lib/mui/theme'
+
+type UTooltipInfoIconProps = {
+  content: string
+  tooltipProps?: TooltipProps
+  iconProps?: SvgIconProps
+  onClick?: () => void
+}
+
+export default function UCardInfo({
+  content,
+  tooltipProps,
+  iconProps,
+  onClick,
+}: UTooltipInfoIconProps) {
+  const theme = useTheme<USTWTheme>()
+
+  return (
+    <Tooltip title={content} arrow {...tooltipProps}>
+      <IconButton size="small" onClick={onClick}>
+        <ErrorOutlineOutlinedIcon
+          {...iconProps}
+          sx={{ color: theme.color.grey[1800], ...iconProps?.sx }}
+        />
+      </IconButton>
+    </Tooltip>
+  )
+}

--- a/src/common/components/atoms/UCardInfo.tsx
+++ b/src/common/components/atoms/UCardInfo.tsx
@@ -10,7 +10,7 @@ import {
 } from '@mui/material'
 import { USTWTheme } from '@/common/lib/mui/theme'
 
-type UTooltipInfoIconProps = {
+type Props = {
   content: string
   tooltipProps?: TooltipProps
   iconProps?: SvgIconProps
@@ -22,7 +22,7 @@ export default function UCardInfo({
   tooltipProps,
   iconProps,
   onClick,
-}: UTooltipInfoIconProps) {
+}: Props) {
   const theme = useTheme<USTWTheme>()
 
   return (

--- a/src/modules/Bill/components/BillCard.tsx
+++ b/src/modules/Bill/components/BillCard.tsx
@@ -14,6 +14,7 @@ import { useMemo } from 'react'
 import { billStatusList } from '@/modules/Bill/constants'
 import UCategoryTag from '@/common/components/atoms/UCategoryTag'
 import { useRouter } from 'next/navigation'
+import UCardInfo from '@/common/components/atoms/UCardInfo'
 
 const DATE_FORMAT = 'MM/DD/YYYY-hh:mmA'
 
@@ -24,12 +25,13 @@ const StyledCardContainer = styled(Stack)(({ theme }) => ({
   backgroundColor: theme.color.common.white,
 }))
 
-const StyledTimelineContainer = styled(Box)(({ theme }) => ({
-  padding: theme.spacing(2.5, 3),
+const StyledTimelineContainer = styled(UHStack)(({ theme }) => ({
+  padding: theme.spacing(2.5, 2, 2.5, 3),
   backgroundColor: theme.color.grey[100],
   borderRadius: '15px',
   minWidth: 275,
   height: 'max-content',
+  gap: theme.spacing(1),
 }))
 
 type Props = {
@@ -146,6 +148,14 @@ export default function BillCard({ mode, simplified, bill }: Props) {
               data={billStatusList}
               activeIndex={bill.statusIndex}
             />
+            <Box>
+              <UCardInfo
+                content={billStatusList[bill.statusIndex].title}
+                iconProps={{
+                  sx: { color: theme.color.neutral[300] },
+                }}
+              />
+            </Box>
           </StyledTimelineContainer>
         )}
       </UHStack>

--- a/src/modules/Bill/components/BillLanding/CongressCard.tsx
+++ b/src/modules/Bill/components/BillLanding/CongressCard.tsx
@@ -2,9 +2,7 @@
 
 import { CongressIcon } from '@/common/styles/assets/Icons'
 import { CardContent, Stack, useTheme } from '@mui/material'
-import UIconButton from '@/common/components/atoms/UIconButton'
 import { USTWTheme } from '@/common/lib/mui/theme'
-import ErrorOutlineOutlinedIcon from '@mui/icons-material/ErrorOutlineOutlined'
 import UContentCard from '@/common/components/atoms/UContentCard'
 import ParliamentChart, {
   ParliamentChartData,
@@ -17,6 +15,7 @@ import { useMemo, useState } from 'react'
 import UHStack from '@/common/components/atoms/UHStack'
 import UButton from '@/common/components/atoms/UButton'
 import { ChamberEnum } from '@/common/enums/Chamber'
+import UCardInfo from '@/common/components/atoms/UCardInfo'
 
 export default function CongressCard() {
   const theme = useTheme<USTWTheme>()
@@ -38,11 +37,7 @@ export default function CongressCard() {
         title: 'Congressional Distribution',
         icon: <CongressIcon />,
         iconColor: 'primary',
-        action: (
-          <UIconButton variant="rounded" color="inherit" size="small">
-            <ErrorOutlineOutlinedIcon sx={{ color: theme.color.grey[1800] }} />
-          </UIconButton>
-        ),
+        action: <UCardInfo content="Congressional Distribution" />,
       }}
     >
       <CardContent sx={{ padding: 0 }}>

--- a/src/modules/Bill/components/BillLanding/SponsorCard.tsx
+++ b/src/modules/Bill/components/BillLanding/SponsorCard.tsx
@@ -2,9 +2,7 @@
 
 import { SponsorIcon } from '@/common/styles/assets/Icons'
 import { CardContent, Stack, Typography, useTheme } from '@mui/material'
-import UIconButton from '@/common/components/atoms/UIconButton'
 import { styled, USTWTheme } from '@/common/lib/mui/theme'
-import ErrorOutlineOutlinedIcon from '@mui/icons-material/ErrorOutlineOutlined'
 import UContentCard from '@/common/components/atoms/UContentCard'
 import UHStack from '@/common/components/atoms/UHStack'
 import { BILL_SPONSOR_MOCK } from '@/modules/Bill/data'
@@ -12,6 +10,7 @@ import { People } from '@/modules/People/classes/People'
 import CircleIcon from '@mui/icons-material/Circle'
 import { Party } from '@/common/enums/Party'
 import usePartyColor from '@/common/lib/Party/usePartyColor'
+import UCardInfo from '@/common/components/atoms/UCardInfo'
 
 const StyledSponsorRowContainer = styled(UHStack)(({ theme }) => ({
   padding: theme.spacing(1.5, 3, 1.5, 2),
@@ -59,8 +58,6 @@ type SponsorCardProps = {
 }
 
 export default function SponsorCard({ isCosponsor }: SponsorCardProps) {
-  const theme = useTheme<USTWTheme>()
-
   return (
     <UContentCard
       withHeader
@@ -69,9 +66,9 @@ export default function SponsorCard({ isCosponsor }: SponsorCardProps) {
         icon: <SponsorIcon />,
         iconColor: 'primary',
         action: (
-          <UIconButton variant="rounded" color="inherit" size="small">
-            <ErrorOutlineOutlinedIcon sx={{ color: theme.color.grey[1800] }} />
-          </UIconButton>
+          <UCardInfo
+            content={isCosponsor ? 'Top 5 Cosponsor' : 'Top 5 Sponsor'}
+          />
         ),
         sx: { borderBottom: 0 },
       }}

--- a/src/modules/Bill/components/BillLanding/TrendCard.tsx
+++ b/src/modules/Bill/components/BillLanding/TrendCard.tsx
@@ -2,12 +2,11 @@
 
 import { TrendIcon } from '@/common/styles/assets/Icons'
 import { Box, CardContent, Stack, Typography, useTheme } from '@mui/material'
-import UIconButton from '@/common/components/atoms/UIconButton'
 import { USTWTheme } from '@/common/lib/mui/theme'
-import ErrorOutlineOutlinedIcon from '@mui/icons-material/ErrorOutlineOutlined'
 import UHStack from '@/common/components/atoms/UHStack'
 import TrendBarCharts from '@/modules/Bill/components/BillLanding/TrendBarCharts'
 import UContentCard from '@/common/components/atoms/UContentCard'
+import UCardInfo from '@/common/components/atoms/UCardInfo'
 
 export default function TrendCard() {
   const theme = useTheme<USTWTheme>()
@@ -19,11 +18,7 @@ export default function TrendCard() {
         title: 'Trends by Category',
         icon: <TrendIcon />,
         iconColor: 'primary',
-        action: (
-          <UIconButton variant="rounded" color="inherit" size="small">
-            <ErrorOutlineOutlinedIcon sx={{ color: theme.color.grey[1800] }} />
-          </UIconButton>
-        ),
+        action: <UCardInfo content="Trends by Category" />,
       }}
     >
       <CardContent sx={{ padding: 0 }}>

--- a/src/modules/Bill/components/IndexBillCard/LeftSection.tsx
+++ b/src/modules/Bill/components/IndexBillCard/LeftSection.tsx
@@ -2,7 +2,6 @@
 
 import UHeightLimitedText from '@/common/components/atoms/UHeightLimitedText'
 import UHStack from '@/common/components/atoms/UHStack'
-import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined'
 import UTimeline from '@/common/components/atoms/UTimeline'
 import { USTWTheme } from '@/common/lib/mui/theme'
 import { Bill } from '@/modules/Bill/classes/Bill'
@@ -11,7 +10,7 @@ import { Box, Stack, Typography, useTheme } from '@mui/material'
 import { billStatusList } from '@/modules/Bill/constants'
 import UCategoryTag from '@/common/components/atoms/UCategoryTag'
 import { BillStatusEnum } from '@/modules/Bill/enums/BillStatus'
-import UIconButton from '@/common/components/atoms/UIconButton'
+import UCardInfo from '@/common/components/atoms/UCardInfo'
 
 type Props = {
   bill: Bill
@@ -49,9 +48,7 @@ export default function LeftSection({ bill }: Props) {
           <Typography variant="articleH4">
             {Bill.GetBillLatestStatus(bill.status ?? BillStatusEnum.INTRODUCED)}
           </Typography>
-          <UIconButton variant="rounded" color="inherit" size="small">
-            <InfoOutlinedIcon sx={{ color: theme.color.grey[1800] }} />
-          </UIconButton>
+          <UCardInfo content="Tracker" />
         </UHStack>
         <Box mx={-6}>
           <UTimeline

--- a/src/modules/Bill/components/SingleBill/BillTracker.tsx
+++ b/src/modules/Bill/components/SingleBill/BillTracker.tsx
@@ -1,21 +1,17 @@
 'use client'
 import UContentCard from '@/common/components/atoms/UContentCard'
 import { TrackerIcon } from '@/common/styles/assets/Icons'
-import { Box, CardContent, useTheme } from '@mui/material'
-import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined'
-import UIconButton from '@/common/components/atoms/UIconButton'
-import { USTWTheme } from '@/common/lib/mui/theme'
+import { Box, CardContent } from '@mui/material'
 import UTimeline from '@/common/components/atoms/UTimeline'
 import { billStatusList } from '@/modules/Bill/constants'
 import { Bill } from '@/modules/Bill/classes/Bill'
+import UCardInfo from '@/common/components/atoms/UCardInfo'
 
 type Props = {
   bill: Bill
 }
 
 export default function BillTracker({ bill }: Props) {
-  const theme = useTheme<USTWTheme>()
-
   return (
     <UContentCard
       withHeader
@@ -23,11 +19,7 @@ export default function BillTracker({ bill }: Props) {
         title: 'Tracker',
         icon: <TrackerIcon />,
         iconColor: 'primary',
-        action: (
-          <UIconButton variant="rounded" color="inherit" size="small">
-            <InfoOutlinedIcon sx={{ color: theme.color.grey[1800] }} />
-          </UIconButton>
-        ),
+        action: <UCardInfo content="Tracker" />,
       }}
     >
       <CardContent>

--- a/src/modules/People/components/PeopleTracker/CardContent/VotesWithParty.tsx
+++ b/src/modules/People/components/PeopleTracker/CardContent/VotesWithParty.tsx
@@ -1,12 +1,11 @@
 import { PeopleCheckIcon } from '@/common/styles/assets/Icons'
 import { Box, CardContent, Stack, Typography, useTheme } from '@mui/material'
-import UIconButton from '@/common/components/atoms/UIconButton'
 import { USTWTheme } from '@/common/lib/mui/theme'
-import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined'
 import { PieChart, PieChartProps } from '@mui/x-charts'
 import type React from 'react'
 import { useMemo } from 'react'
 import UContentCard from '@/common/components/atoms/UContentCard'
+import UCardInfo from '@/common/components/atoms/UCardInfo'
 
 // TODO: 確認比例來源
 const MOCK_VOTES_WITH_PARTY_PERCENTAGE = 96.12345
@@ -58,7 +57,6 @@ const PieCenterLabel = function PieCenterLabel({ value }: { value: number }) {
 }
 
 const VotesWithParty = function VotesWithParty() {
-  const theme = useTheme<USTWTheme>()
   const { percentage, data } = useVotesWithPartyPercentage()
   return (
     <UContentCard
@@ -67,11 +65,7 @@ const VotesWithParty = function VotesWithParty() {
         title: 'Votes with Party',
         icon: <PeopleCheckIcon />,
         iconColor: 'secondary',
-        action: (
-          <UIconButton variant="rounded" color="inherit" size="small">
-            <InfoOutlinedIcon sx={{ color: theme.color.grey[1800] }} />
-          </UIconButton>
-        ),
+        action: <UCardInfo content="Votes" />,
       }}
     >
       <CardContent sx={{ padding: 0 }}>


### PR DESCRIPTION
## Summary

卡片上的 info icon 用於說明卡片用途，獨立成共用元件，並保留 onClick 擴充功能。

![截圖 2024-10-03 晚上8 53 27](https://github.com/user-attachments/assets/51a5709b-694e-42a2-aa95-12385d31ba31)

## Test Plan

https://github.com/user-attachments/assets/3023e837-bf8e-4fd1-bb12-23d791e6425b
