### PR TITLE
refactor: UContentCard 合併 Modal 及 Tooltip 模式

### DIFF
--- a/src/common/components/atoms/UCardInfo.tsx
+++ b/src/common/components/atoms/UCardInfo.tsx
@@ -10,7 +10,7 @@ import {
 } from '@mui/material'
 import { USTWTheme } from '@/common/lib/mui/theme'
 
-type Props = {
+export type UCardInfoProps = {
   content: string
   tooltipProps?: TooltipProps
   iconProps?: SvgIconProps
@@ -22,7 +22,7 @@ export default function UCardInfo({
   tooltipProps,
   iconProps,
   onClick,
-}: Props) {
+}: UCardInfoProps) {
   const theme = useTheme<USTWTheme>()
 
   return (

--- a/src/common/components/atoms/UContentCard.tsx
+++ b/src/common/components/atoms/UContentCard.tsx
@@ -17,6 +17,7 @@ import React, { cloneElement } from 'react'
 import ArrowForwardIcon from '@mui/icons-material/ArrowForward'
 import CloseIcon from '@mui/icons-material/Close'
 import UContentCardDialog from '@/common/components/atoms/UContentCardDialog'
+import UCardInfo, { UCardInfoProps } from '@/common/components/atoms/UCardInfo'
 
 type HeaderIconAction = 'tooltip' | 'modal'
 
@@ -41,7 +42,8 @@ interface UContentCardProps extends CardProps {
    * 點擊事件
    */
   onActionClick?: () => void
-  /** TODO: 實作 Tooltip 相關參數 */
+  /** Tooltip 相關參數 */
+  tooltipProps?: UCardInfoProps
 }
 
 const StyledContentCard = styled(Card)(({ theme }) => ({
@@ -93,6 +95,7 @@ const UContentCard = function UContentCard({
   modalContent,
   isModal,
   onActionClick,
+  tooltipProps,
   ...rest
 }: UContentCardProps) {
   const theme = useTheme<USTWTheme>()
@@ -119,7 +122,7 @@ const UContentCard = function UContentCard({
         {...headerProps}
         action={
           headerIconAction === 'modal' ? (
-            headerProps?.action && headerProps.action ? (
+            headerProps?.action ? (
               cloneElement(headerProps.action as React.ReactElement, {
                 onClick: handleActionClick,
               })
@@ -137,6 +140,8 @@ const UContentCard = function UContentCard({
                 )}
               </UIconButton>
             )
+          ) : headerIconAction === 'tooltip' && tooltipProps ? (
+            <UCardInfo {...tooltipProps} />
           ) : (
             headerProps?.action
           )

--- a/src/common/components/atoms/UContentCard.tsx
+++ b/src/common/components/atoms/UContentCard.tsx
@@ -114,10 +114,7 @@ const UContentCard = function UContentCard({
   }
 
   return (
-    <StyledContentCardWithHeader
-      {...rest}
-      overflowHidden={headerIconAction === 'modal'}
-    >
+    <StyledContentCardWithHeader {...rest}>
       <UCardHeader
         {...headerProps}
         action={

--- a/src/common/components/atoms/UContentCard.tsx
+++ b/src/common/components/atoms/UContentCard.tsx
@@ -13,7 +13,7 @@ import {
   CardProps,
   useTheme,
 } from '@mui/material'
-import React, { cloneElement } from 'react'
+import React, { cloneElement, useCallback, useMemo } from 'react'
 import ArrowForwardIcon from '@mui/icons-material/ArrowForward'
 import CloseIcon from '@mui/icons-material/Close'
 import UContentCardDialog from '@/common/components/atoms/UContentCardDialog'
@@ -101,13 +101,49 @@ const UContentCard = function UContentCard({
   const theme = useTheme<USTWTheme>()
   const { isModalOpen, handleOpenModal, handleCloseModal } = useModal()
 
-  const handleActionClick = () => {
+  const handleActionClick = useCallback(() => {
     if (!isModal) {
       handleOpenModal()
     } else {
       onActionClick?.()
     }
-  }
+  }, [isModal, handleOpenModal, onActionClick])
+
+  const action = useMemo(() => {
+    if (headerIconAction === 'modal') {
+      if (headerProps?.action) {
+        return cloneElement(headerProps.action as React.ReactElement, {
+          onClick: handleActionClick,
+        })
+      } else {
+        return (
+          <UIconButton
+            variant="rounded"
+            color="inherit"
+            size="small"
+            onClick={handleActionClick}
+          >
+            {isModal ? (
+              <CloseIcon sx={{ color: theme.color.neutral[500] }} />
+            ) : (
+              <ArrowForwardIcon sx={{ color: theme.color.neutral[500] }} />
+            )}
+          </UIconButton>
+        )
+      }
+    } else if (headerIconAction === 'tooltip' && tooltipProps) {
+      return <UCardInfo {...tooltipProps} />
+    } else {
+      return headerProps?.action
+    }
+  }, [
+    theme,
+    headerIconAction,
+    isModal,
+    headerProps?.action,
+    tooltipProps,
+    handleActionClick,
+  ])
 
   if (!withHeader) {
     return <StyledContentCard {...rest}>{children}</StyledContentCard>
@@ -115,35 +151,7 @@ const UContentCard = function UContentCard({
 
   return (
     <StyledContentCardWithHeader {...rest}>
-      <UCardHeader
-        {...headerProps}
-        action={
-          headerIconAction === 'modal' ? (
-            headerProps?.action ? (
-              cloneElement(headerProps.action as React.ReactElement, {
-                onClick: handleActionClick,
-              })
-            ) : (
-              <UIconButton
-                variant="rounded"
-                color="inherit"
-                size="small"
-                onClick={handleActionClick}
-              >
-                {isModal ? (
-                  <CloseIcon sx={{ color: theme.color.neutral[500] }} />
-                ) : (
-                  <ArrowForwardIcon sx={{ color: theme.color.neutral[500] }} />
-                )}
-              </UIconButton>
-            )
-          ) : headerIconAction === 'tooltip' && tooltipProps ? (
-            <UCardInfo {...tooltipProps} />
-          ) : (
-            headerProps?.action
-          )
-        }
-      />
+      <UCardHeader {...headerProps} action={action} />
       <CardContent
         sx={{
           padding: 0,

--- a/src/common/components/elements/IdeologyLeadershipChart/index.tsx
+++ b/src/common/components/elements/IdeologyLeadershipChart/index.tsx
@@ -4,7 +4,7 @@ import { USTWTheme } from '@/common/lib/mui/theme'
 import { useTheme } from '@mui/material'
 import Highcharts from 'highcharts'
 import HighchartsReact from 'highcharts-react-official'
-import { memo, useCallback, useMemo } from 'react'
+import React, { memo, useCallback, useMemo } from 'react'
 
 type IdeologyLeadershipDataItem = {
   ID: string

--- a/src/modules/Bill/components/BillLanding/CongressCard.tsx
+++ b/src/modules/Bill/components/BillLanding/CongressCard.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { CongressIcon } from '@/common/styles/assets/Icons'
-import { CardContent, Stack, useTheme } from '@mui/material'
+import { Stack, useTheme } from '@mui/material'
 import { USTWTheme } from '@/common/lib/mui/theme'
 import UContentCard from '@/common/components/atoms/UContentCard'
 import ParliamentChart, {
@@ -40,33 +40,31 @@ export default function CongressCard() {
         action: <UCardInfo content="Congressional Distribution" />,
       }}
     >
-      <CardContent sx={{ padding: 0 }}>
-        <Stack pt={2} alignItems="center">
-          <ParliamentChart data={data} />
-          <UHStack alignItems="center" justifyContent="center" spacing={2}>
-            {[ChamberEnum.HOUSE, ChamberEnum.SENATE].map((congress) => (
-              <UButton
-                key={congress}
-                variant="contained"
-                color="primary"
-                sx={{
-                  backgroundColor:
-                    selectedChamber === congress
-                      ? theme.color.purple[100]
-                      : theme.color.neutral[100],
-                  fontWeight: 600,
-                  fontSize: 16,
-                }}
-                rounded
-                size="small"
-                onClick={() => setSelectedChamber(congress)}
-              >
-                {congress}
-              </UButton>
-            ))}
-          </UHStack>
-        </Stack>
-      </CardContent>
+      <Stack pt={2} alignItems="center">
+        <ParliamentChart data={data} />
+        <UHStack alignItems="center" justifyContent="center" spacing={2}>
+          {[ChamberEnum.HOUSE, ChamberEnum.SENATE].map((congress) => (
+            <UButton
+              key={congress}
+              variant="contained"
+              color="primary"
+              sx={{
+                backgroundColor:
+                  selectedChamber === congress
+                    ? theme.color.purple[100]
+                    : theme.color.neutral[100],
+                fontWeight: 600,
+                fontSize: 16,
+              }}
+              rounded
+              size="small"
+              onClick={() => setSelectedChamber(congress)}
+            >
+              {congress}
+            </UButton>
+          ))}
+        </UHStack>
+      </Stack>
     </UContentCard>
   )
 }

--- a/src/modules/Bill/components/BillLanding/CongressCard.tsx
+++ b/src/modules/Bill/components/BillLanding/CongressCard.tsx
@@ -15,7 +15,6 @@ import { useMemo, useState } from 'react'
 import UHStack from '@/common/components/atoms/UHStack'
 import UButton from '@/common/components/atoms/UButton'
 import { ChamberEnum } from '@/common/enums/Chamber'
-import UCardInfo from '@/common/components/atoms/UCardInfo'
 
 export default function CongressCard() {
   const theme = useTheme<USTWTheme>()
@@ -32,12 +31,15 @@ export default function CongressCard() {
 
   return (
     <UContentCard
+      headerIconAction="tooltip"
       withHeader
       headerProps={{
         title: 'Congressional Distribution',
         icon: <CongressIcon />,
         iconColor: 'primary',
-        action: <UCardInfo content="Congressional Distribution" />,
+      }}
+      tooltipProps={{
+        content: 'Congressional Distribution',
       }}
     >
       <Stack pt={2} alignItems="center">

--- a/src/modules/Bill/components/BillLanding/SponsorCard.tsx
+++ b/src/modules/Bill/components/BillLanding/SponsorCard.tsx
@@ -10,7 +10,6 @@ import { People } from '@/modules/People/classes/People'
 import CircleIcon from '@mui/icons-material/Circle'
 import { Party } from '@/common/enums/Party'
 import usePartyColor from '@/common/lib/Party/usePartyColor'
-import UCardInfo from '@/common/components/atoms/UCardInfo'
 
 const StyledSponsorRowContainer = styled(UHStack)(({ theme }) => ({
   padding: theme.spacing(1.5, 3, 1.5, 2),
@@ -60,17 +59,16 @@ type SponsorCardProps = {
 export default function SponsorCard({ isCosponsor }: SponsorCardProps) {
   return (
     <UContentCard
+      headerIconAction="tooltip"
       withHeader
       headerProps={{
         title: isCosponsor ? 'Top 5 Cosponsor' : 'Top 5 Sponsor',
         icon: <SponsorIcon />,
         iconColor: 'primary',
-        action: (
-          <UCardInfo
-            content={isCosponsor ? 'Top 5 Cosponsor' : 'Top 5 Sponsor'}
-          />
-        ),
         sx: { borderBottom: 0 },
+      }}
+      tooltipProps={{
+        content: isCosponsor ? 'Top 5 Cosponsor' : 'Top 5 Sponsor',
       }}
     >
       <Stack spacing={1} pt={2}>

--- a/src/modules/Bill/components/BillLanding/SponsorCard.tsx
+++ b/src/modules/Bill/components/BillLanding/SponsorCard.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { SponsorIcon } from '@/common/styles/assets/Icons'
-import { CardContent, Stack, Typography, useTheme } from '@mui/material'
+import { Stack, Typography, useTheme } from '@mui/material'
 import { styled, USTWTheme } from '@/common/lib/mui/theme'
 import UContentCard from '@/common/components/atoms/UContentCard'
 import UHStack from '@/common/components/atoms/UHStack'
@@ -73,13 +73,11 @@ export default function SponsorCard({ isCosponsor }: SponsorCardProps) {
         sx: { borderBottom: 0 },
       }}
     >
-      <CardContent sx={{ padding: 0 }}>
-        <Stack spacing={1} pt={2}>
-          {BILL_SPONSOR_MOCK.map((sponsor, index) => (
-            <SponsorRow key={index} sponsor={sponsor} />
-          ))}
-        </Stack>
-      </CardContent>
+      <Stack spacing={1} pt={2}>
+        {BILL_SPONSOR_MOCK.map((sponsor, index) => (
+          <SponsorRow key={index} sponsor={sponsor} />
+        ))}
+      </Stack>
     </UContentCard>
   )
 }

--- a/src/modules/Bill/components/BillLanding/TrendCard.tsx
+++ b/src/modules/Bill/components/BillLanding/TrendCard.tsx
@@ -11,7 +11,6 @@ import UContentCard from '@/common/components/atoms/UContentCard'
 import useBillFilterOptions from '@/modules/Bill/components/BillFilter/useBillFilterOptions'
 import USelect from '@/common/components/atoms/USelect'
 import { useMemo, useState } from 'react'
-import UCardInfo from '@/common/components/atoms/UCardInfo'
 
 const dataAll: TrendBarChartData[] = [
   { session: 113, count: 15 },
@@ -40,12 +39,15 @@ export default function TrendCard() {
 
   return (
     <UContentCard
+      headerIconAction="tooltip"
       withHeader
       headerProps={{
         title: 'Trends by Category',
         icon: <TrendIcon />,
         iconColor: 'primary',
-        action: <UCardInfo content="Trends by Category" />,
+      }}
+      tooltipProps={{
+        content: 'Trends by Category',
       }}
     >
       <Stack mt={3} px={1.5}>

--- a/src/modules/Bill/components/BillLanding/TrendCard.tsx
+++ b/src/modules/Bill/components/BillLanding/TrendCard.tsx
@@ -1,14 +1,7 @@
 'use client'
 
 import { TrendIcon } from '@/common/styles/assets/Icons'
-import {
-  Box,
-  CardContent,
-  MenuItem,
-  Stack,
-  Typography,
-  useTheme,
-} from '@mui/material'
+import { Box, MenuItem, Stack, Typography, useTheme } from '@mui/material'
 import { USTWTheme } from '@/common/lib/mui/theme'
 import UHStack from '@/common/components/atoms/UHStack'
 import TrendBarCharts, {
@@ -55,35 +48,33 @@ export default function TrendCard() {
         action: <UCardInfo content="Trends by Category" />,
       }}
     >
-      <CardContent sx={{ padding: 0 }}>
-        <Stack mt={3} px={1.5}>
-          <UHStack justifyContent="space-between">
-            <Stack spacing={1}>
-              <Typography variant="menu" color={theme.color.grey[2200]}>
-                Total
-              </Typography>
-              <Typography variant="h4">2048</Typography>
-            </Stack>
+      <Stack mt={3} px={1.5}>
+        <UHStack justifyContent="space-between">
+          <Stack spacing={1}>
+            <Typography variant="menu" color={theme.color.grey[2200]}>
+              Total
+            </Typography>
+            <Typography variant="h4">2048</Typography>
+          </Stack>
 
-            <Box>
-              <USelect
-                value={selectedCategory}
-                onChange={(e) => setSelectedCategory(String(e.target.value))}
-              >
-                <MenuItem value="">All</MenuItem>
-                {categoryOptions.map((option) => (
-                  <MenuItem key={option.value} value={option.value}>
-                    {option.label}
-                  </MenuItem>
-                ))}
-              </USelect>
-            </Box>
-          </UHStack>
-          <Box width="100%">
-            <TrendBarCharts data={chartData} />
+          <Box>
+            <USelect
+              value={selectedCategory}
+              onChange={(e) => setSelectedCategory(String(e.target.value))}
+            >
+              <MenuItem value="">All</MenuItem>
+              {categoryOptions.map((option) => (
+                <MenuItem key={option.value} value={option.value}>
+                  {option.label}
+                </MenuItem>
+              ))}
+            </USelect>
           </Box>
-        </Stack>
-      </CardContent>
+        </UHStack>
+        <Box width="100%">
+          <TrendBarCharts data={chartData} />
+        </Box>
+      </Stack>
     </UContentCard>
   )
 }

--- a/src/modules/Bill/components/SingleBill/ActionsDialog/index.tsx
+++ b/src/modules/Bill/components/SingleBill/ActionsDialog/index.tsx
@@ -7,7 +7,7 @@ import { ActionsIcon } from '@/common/styles/assets/Icons'
 import { Bill } from '@/modules/Bill/classes/Bill'
 import CloseIcon from '@mui/icons-material/Close'
 import { USTWTheme } from '@/common/lib/mui/theme'
-import { CardContent, Grid2, useTheme } from '@mui/material'
+import { Grid2, useTheme } from '@mui/material'
 import DialogFilter, {
   FilterCategory,
 } from '@/modules/Bill/components/SingleBill/DialogFilter'
@@ -108,28 +108,27 @@ export default function ActionsDialog({
           border: 'none',
           borderRadius: 0,
         }}
-      >
-        <CardContent
-          sx={{
+        contentProps={{
+          sx: {
             '&.MuiCardContent-root': {
               overflowY: 'hidden',
             },
-          }}
-        >
-          <Grid2 container mt={2} spacing={2}>
-            <Grid2 size={3} pl={1} pt="3px">
-              <DialogFilter
-                selectedOptionIdList={selectedOptionIdList}
-                onSelectOption={handleSelectOption}
-                toggleSelectAllOption={toggleSelectAllOption}
-                categories={categories}
-              />
-            </Grid2>
-            <Grid2 size={9}>
-              <ActionsTable actions={bill.actions ?? []} />
-            </Grid2>
+          },
+        }}
+      >
+        <Grid2 container mt={2} spacing={2}>
+          <Grid2 size={3} pl={1} pt="3px">
+            <DialogFilter
+              selectedOptionIdList={selectedOptionIdList}
+              onSelectOption={handleSelectOption}
+              toggleSelectAllOption={toggleSelectAllOption}
+              categories={categories}
+            />
           </Grid2>
-        </CardContent>
+          <Grid2 size={9}>
+            <ActionsTable actions={bill.actions ?? []} />
+          </Grid2>
+        </Grid2>
       </UContentCard>
     </UContentCardDialog>
   )

--- a/src/modules/Bill/components/SingleBill/BillActions.tsx
+++ b/src/modules/Bill/components/SingleBill/BillActions.tsx
@@ -1,7 +1,7 @@
 'use client'
 import UContentCard from '@/common/components/atoms/UContentCard'
 import { ActionsIcon } from '@/common/styles/assets/Icons'
-import { CardContent, Stack, Typography, useTheme } from '@mui/material'
+import { Stack, Typography, useTheme } from '@mui/material'
 import ArrowForwardIcon from '@mui/icons-material/ArrowForward'
 import UIconButton from '@/common/components/atoms/UIconButton'
 import { USTWTheme } from '@/common/lib/mui/theme'
@@ -43,33 +43,31 @@ export default function BillActions({ bill }: Props) {
           ),
         }}
       >
-        <CardContent>
-          <Stack pt={2}>
-            <UHStack alignItems="center" justifyContent="space-between" mb={2}>
-              <UCategoryTag
-                value={bill.latestAction?.chamber}
-                containerProps={{
-                  sx: {
-                    backgroundColor: `${theme.color.purple[100]}80`, // 50% opacity
-                  },
-                }}
-                textProps={{
-                  variant: 'buttonS',
-                }}
-              />
+        <Stack pt={2}>
+          <UHStack alignItems="center" justifyContent="space-between" mb={2}>
+            <UCategoryTag
+              value={bill.latestAction?.chamber}
+              containerProps={{
+                sx: {
+                  backgroundColor: `${theme.color.purple[100]}80`, // 50% opacity
+                },
+              }}
+              textProps={{
+                variant: 'buttonS',
+              }}
+            />
 
-              <Typography variant="buttonXS">
-                {dayjs(bill.latestAction?.date).isValid()
-                  ? dayjs(bill.latestAction?.date).format(DATE_FORMAT)
-                  : ''}
-              </Typography>
-            </UHStack>
+            <Typography variant="buttonXS">
+              {dayjs(bill.latestAction?.date).isValid()
+                ? dayjs(bill.latestAction?.date).format(DATE_FORMAT)
+                : ''}
+            </Typography>
+          </UHStack>
 
-            <UHeightLimitedText maxLine={4} variant="body">
-              {bill.latestAction?.description}
-            </UHeightLimitedText>
-          </Stack>
-        </CardContent>
+          <UHeightLimitedText maxLine={4} variant="body">
+            {bill.latestAction?.description}
+          </UHeightLimitedText>
+        </Stack>
       </UContentCard>
 
       <ActionsDialog

--- a/src/modules/Bill/components/SingleBill/BillCosponsors.tsx
+++ b/src/modules/Bill/components/SingleBill/BillCosponsors.tsx
@@ -1,7 +1,7 @@
 'use client'
 import UContentCard from '@/common/components/atoms/UContentCard'
 import { CosponsorsIcon } from '@/common/styles/assets/Icons'
-import { CardContent, useTheme } from '@mui/material'
+import { useTheme } from '@mui/material'
 import ArrowForwardIcon from '@mui/icons-material/ArrowForward'
 import UIconButton from '@/common/components/atoms/UIconButton'
 import { USTWTheme } from '@/common/lib/mui/theme'
@@ -40,16 +40,15 @@ export default function BillCosponsors({ bill }: Props) {
             </UIconButton>
           ),
         }}
-      >
-        <CardContent
-          sx={{
+        contentProps={{
+          sx: {
             display: 'flex',
             flexDirection: 'column',
             alignItems: 'center',
-          }}
-        >
-          <CosponsorChart data={data} />
-        </CardContent>
+          },
+        }}
+      >
+        <CosponsorChart data={data} />
       </UContentCard>
 
       <CosponsorDialog

--- a/src/modules/Bill/components/SingleBill/BillTracker.tsx
+++ b/src/modules/Bill/components/SingleBill/BillTracker.tsx
@@ -5,7 +5,6 @@ import { Box } from '@mui/material'
 import UTimeline from '@/common/components/atoms/UTimeline'
 import { billStatusList } from '@/modules/Bill/constants'
 import { Bill } from '@/modules/Bill/classes/Bill'
-import UCardInfo from '@/common/components/atoms/UCardInfo'
 
 type Props = {
   bill: Bill
@@ -14,12 +13,15 @@ type Props = {
 export default function BillTracker({ bill }: Props) {
   return (
     <UContentCard
+      headerIconAction="tooltip"
       withHeader
       headerProps={{
         title: 'Tracker',
         icon: <TrackerIcon />,
         iconColor: 'primary',
-        action: <UCardInfo content="Tracker" />,
+      }}
+      tooltipProps={{
+        content: 'Tracker',
       }}
     >
       <Box pt={2} px={1}>

--- a/src/modules/Bill/components/SingleBill/BillTracker.tsx
+++ b/src/modules/Bill/components/SingleBill/BillTracker.tsx
@@ -1,7 +1,7 @@
 'use client'
 import UContentCard from '@/common/components/atoms/UContentCard'
 import { TrackerIcon } from '@/common/styles/assets/Icons'
-import { Box, CardContent } from '@mui/material'
+import { Box } from '@mui/material'
 import UTimeline from '@/common/components/atoms/UTimeline'
 import { billStatusList } from '@/modules/Bill/constants'
 import { Bill } from '@/modules/Bill/classes/Bill'
@@ -22,15 +22,13 @@ export default function BillTracker({ bill }: Props) {
         action: <UCardInfo content="Tracker" />,
       }}
     >
-      <CardContent>
-        <Box pt={2} px={1}>
-          <UTimeline
-            data={billStatusList}
-            activeIndex={bill.statusIndex}
-            itemMinHeight={50}
-          />
-        </Box>
-      </CardContent>
+      <Box pt={2} px={1}>
+        <UTimeline
+          data={billStatusList}
+          activeIndex={bill.statusIndex}
+          itemMinHeight={50}
+        />
+      </Box>
     </UContentCard>
   )
 }

--- a/src/modules/Bill/components/SingleBill/BioByAI.tsx
+++ b/src/modules/Bill/components/SingleBill/BioByAI.tsx
@@ -3,102 +3,53 @@
 import UButton from '@/common/components/atoms/UButton'
 import UContentCard from '@/common/components/atoms/UContentCard'
 import { StarsIcon } from '@/common/styles/assets/Icons'
-import { CardContent, Typography, useTheme } from '@mui/material'
+import { Typography, useTheme } from '@mui/material'
 import ArrowForwardIcon from '@mui/icons-material/ArrowForward'
 import { USTWTheme } from '@/common/lib/mui/theme'
-import UIconButton from '@/common/components/atoms/UIconButton'
-import CloseIcon from '@mui/icons-material/Close'
-import UContentCardDialog from '@/common/components/atoms/UContentCardDialog'
-import useModal from '@/common/hooks/useModal'
 
-type BioByAIProps = {
-  isModal?: boolean
-  onActionClick?: () => void
-}
-
-export default function BioByAI({ isModal, onActionClick }: BioByAIProps) {
+export default function BioByAI() {
   const theme = useTheme<USTWTheme>()
-  const { isModalOpen, handleOpenModal, handleCloseModal } = useModal()
-
-  const handleActionClick = () => {
-    if (isModal) {
-      onActionClick?.()
-    } else {
-      handleOpenModal()
-    }
-  }
-
-  const renderAction = () => {
-    if (isModal) {
-      return (
-        <UIconButton
-          variant="rounded"
-          color="inherit"
-          size="small"
-          onClick={handleActionClick}
-        >
-          <CloseIcon sx={{ color: theme.color.neutral[500] }} />
-        </UIconButton>
-      )
-    }
-
-    return (
-      <UButton
-        endIcon={<ArrowForwardIcon sx={{ color: theme.color.neutral[500] }} />}
-        color="info"
-        variant="outlined"
-        size="small"
-        sx={{
-          py: 0.5,
-          px: 1,
-          borderRadius: '9px',
-          border: `1.5px solid ${theme.color.grey[1400]}`,
-        }}
-        onClick={handleActionClick}
-      >
-        <Typography variant="buttonXS">Full Text</Typography>
-      </UButton>
-    )
-  }
 
   return (
     <UContentCard
+      headerIconAction="modal"
       withHeader
       headerProps={{
         title: 'Summary From AI',
         icon: <StarsIcon />,
         iconColor: 'primary',
-        action: renderAction(),
-      }}
-      sx={{
-        ...(isModal && {
-          padding: 0,
-          border: 'none',
-          borderRadius: 0,
-        }),
+        action: (
+          <UButton
+            endIcon={
+              <ArrowForwardIcon sx={{ color: theme.color.neutral[500] }} />
+            }
+            color="info"
+            variant="outlined"
+            size="small"
+            sx={{
+              py: 0.5,
+              px: 1,
+              borderRadius: '9px',
+              border: `1.5px solid ${theme.color.grey[1400]}`,
+            }}
+          >
+            <Typography variant="buttonXS">Full Text</Typography>
+          </UButton>
+        ),
       }}
     >
-      <CardContent>
-        <Typography variant="body" pt={2}>
-          Senator Pete Ricketts, a Republican, is the junior senator from
-          Nebraska, appointed on January 23, 2023. He is up for reelection in
-          2024. Ricketts strongly advocates for Taiwan’s security. He
-          co-sponsored the BOLSTER Act to facilitate U.S.-made defense equipment
-          transfers from European NATO countries to Taiwan and promote
-          coordinated sanctions against China. He supports strengthening
-          economic and political ties between Taiwan, the U.S., and Europe,
-          focusing on Taiwan’s integration into international organizations and
-          economic resilience, especially in semiconductors. Ricketts also
-          emphasizes humanitarian aid for Taiwan and counters Chinese propaganda
-          to support Taiwan’s democracy.
-        </Typography>
-      </CardContent>
-
-      {isModalOpen && (
-        <UContentCardDialog open={isModalOpen} onClose={handleCloseModal}>
-          <BioByAI isModal onActionClick={handleCloseModal} />
-        </UContentCardDialog>
-      )}
+      <Typography variant="body" pt={2}>
+        Senator Pete Ricketts, a Republican, is the junior senator from
+        Nebraska, appointed on January 23, 2023. He is up for reelection in
+        2024. Ricketts strongly advocates for Taiwan’s security. He co-sponsored
+        the BOLSTER Act to facilitate U.S.-made defense equipment transfers from
+        European NATO countries to Taiwan and promote coordinated sanctions
+        against China. He supports strengthening economic and political ties
+        between Taiwan, the U.S., and Europe, focusing on Taiwan’s integration
+        into international organizations and economic resilience, especially in
+        semiconductors. Ricketts also emphasizes humanitarian aid for Taiwan and
+        counters Chinese propaganda to support Taiwan’s democracy.
+      </Typography>
     </UContentCard>
   )
 }

--- a/src/modules/Bill/components/SingleBill/CosponsorDialog/index.tsx
+++ b/src/modules/Bill/components/SingleBill/CosponsorDialog/index.tsx
@@ -7,7 +7,7 @@ import { CosponsorsIcon } from '@/common/styles/assets/Icons'
 import { Bill } from '@/modules/Bill/classes/Bill'
 import CloseIcon from '@mui/icons-material/Close'
 import { USTWTheme } from '@/common/lib/mui/theme'
-import { CardContent, Grid2, useTheme } from '@mui/material'
+import { Grid2, useTheme } from '@mui/material'
 import DialogFilter, {
   FilterCategory,
 } from '@/modules/Bill/components/SingleBill/DialogFilter'
@@ -108,28 +108,27 @@ export default function CosponsorDialog({
           border: 'none',
           borderRadius: 0,
         }}
-      >
-        <CardContent
-          sx={{
+        contentProps={{
+          sx: {
             '&.MuiCardContent-root': {
               overflowY: 'hidden',
             },
-          }}
-        >
-          <Grid2 container mt={2} spacing={2}>
-            <Grid2 size={3} pl={1} pt="3px">
-              <DialogFilter
-                selectedOptionIdList={selectedOptionIdList}
-                onSelectOption={handleSelectOption}
-                toggleSelectAllOption={toggleSelectAllOption}
-                categories={categories}
-              />
-            </Grid2>
-            <Grid2 size={9}>
-              <CosponsorTable cosponsors={bill.cosponsors ?? []} />
-            </Grid2>
+          },
+        }}
+      >
+        <Grid2 container mt={2} spacing={2}>
+          <Grid2 size={3} pl={1} pt="3px">
+            <DialogFilter
+              selectedOptionIdList={selectedOptionIdList}
+              onSelectOption={handleSelectOption}
+              toggleSelectAllOption={toggleSelectAllOption}
+              categories={categories}
+            />
           </Grid2>
-        </CardContent>
+          <Grid2 size={9}>
+            <CosponsorTable cosponsors={bill.cosponsors ?? []} />
+          </Grid2>
+        </Grid2>
       </UContentCard>
     </UContentCardDialog>
   )

--- a/src/modules/Bill/components/SingleBill/Sponsor.tsx
+++ b/src/modules/Bill/components/SingleBill/Sponsor.tsx
@@ -1,7 +1,7 @@
 'use client'
 import UContentCard from '@/common/components/atoms/UContentCard'
 import { SponsorIcon } from '@/common/styles/assets/Icons'
-import { Box, CardContent, Stack, Typography } from '@mui/material'
+import { Box, Stack, Typography } from '@mui/material'
 import { styled } from '@/common/lib/mui/theme'
 import { Bill } from '@/modules/Bill/classes/Bill'
 import UHStack from '@/common/components/atoms/UHStack'
@@ -35,34 +35,32 @@ export default function Sponsor({ bill }: Props) {
         iconColor: 'primary',
       }}
     >
-      <CardContent>
-        <UHStack pt={2} spacing={3}>
-          {bill.sponsor?.image && (
-            <StyledImageContainer>
-              <StyledImage
-                src={bill.sponsor.image}
-                alt={bill.sponsor.name ?? ''}
-                fill
-              />
-            </StyledImageContainer>
-          )}
+      <UHStack pt={2} spacing={3}>
+        {bill.sponsor?.image && (
+          <StyledImageContainer>
+            <StyledImage
+              src={bill.sponsor.image}
+              alt={bill.sponsor.name ?? ''}
+              fill
+            />
+          </StyledImageContainer>
+        )}
 
-          <Stack justifyContent="space-between">
-            <Stack spacing={1}>
-              <Typography variant="articleH3">{bill.sponsor?.name}</Typography>
-              <Typography variant="body">{bill.sponsor?.position}</Typography>
-            </Stack>
-
-            <Typography
-              variant="buttonXS"
-              fontWeight={700}
-              textTransform="capitalize"
-            >
-              {bill.sponsor?.party?.toLowerCase()}
-            </Typography>
+        <Stack justifyContent="space-between">
+          <Stack spacing={1}>
+            <Typography variant="articleH3">{bill.sponsor?.name}</Typography>
+            <Typography variant="body">{bill.sponsor?.position}</Typography>
           </Stack>
-        </UHStack>
-      </CardContent>
+
+          <Typography
+            variant="buttonXS"
+            fontWeight={700}
+            textTransform="capitalize"
+          >
+            {bill.sponsor?.party?.toLowerCase()}
+          </Typography>
+        </Stack>
+      </UHStack>
     </UContentCard>
   )
 }

--- a/src/modules/Bill/components/SingleBill/TitleVersionDialog.tsx
+++ b/src/modules/Bill/components/SingleBill/TitleVersionDialog.tsx
@@ -6,7 +6,6 @@ import { VersionIcon } from '@/common/styles/assets/Icons'
 import CloseIcon from '@mui/icons-material/Close'
 import { USTWTheme } from '@/common/lib/mui/theme'
 import {
-  CardContent,
   Collapse,
   Stack,
   StackProps,
@@ -111,28 +110,26 @@ export default function TitleVersionDialog({
           borderRadius: 0,
         }}
       >
-        <CardContent>
-          <Stack
-            pt={2}
-            sx={{
-              '& > *': {
-                padding: theme.spacing(2.5, 6),
-              },
-            }}
-          >
-            <Typography variant="articleH4">
-              {`${bill.chamberPrefix}${bill.id} | ${CONGRESS_CURRENT_SESSION_MOCK}th Congress (2023-2024)`}
-            </Typography>
-            {bill.previousTitles?.map((title, index) => (
-              <TitleRow
-                key={index}
-                title={title}
-                // TODO: 待釐清設計稿中的文字意涵，暫以假文案代之
-                description={FAKE_DESCRIPTION}
-              />
-            ))}
-          </Stack>
-        </CardContent>
+        <Stack
+          pt={2}
+          sx={{
+            '& > *': {
+              padding: theme.spacing(2.5, 6),
+            },
+          }}
+        >
+          <Typography variant="articleH4">
+            {`${bill.chamberPrefix}${bill.id} | ${CONGRESS_CURRENT_SESSION_MOCK}th Congress (2023-2024)`}
+          </Typography>
+          {bill.previousTitles?.map((title, index) => (
+            <TitleRow
+              key={index}
+              title={title}
+              // TODO: 待釐清設計稿中的文字意涵，暫以假文案代之
+              description={FAKE_DESCRIPTION}
+            />
+          ))}
+        </Stack>
       </UContentCard>
     </UContentCardDialog>
   )

--- a/src/modules/People/components/PeopleTracker/CardContent/BioByAI.tsx
+++ b/src/modules/People/components/PeopleTracker/CardContent/BioByAI.tsx
@@ -12,6 +12,7 @@ const BioByAI = function BioByAI() {
         icon: <StarsIcon />,
         iconColor: 'primary',
       }}
+      overflowHidden
     >
       <Typography component="p">
         Senator Pete Ricketts, a Republican, is the junior senator from

--- a/src/modules/People/components/PeopleTracker/CardContent/BioByAI.tsx
+++ b/src/modules/People/components/PeopleTracker/CardContent/BioByAI.tsx
@@ -1,10 +1,11 @@
 import UContentCard from '@/common/components/atoms/UContentCard'
 import { StarsIcon } from '@/common/styles/assets/Icons'
-import { CardContent, Typography } from '@mui/material'
+import { Typography } from '@mui/material'
 
 const BioByAI = function BioByAI() {
   return (
     <UContentCard
+      headerIconAction="modal"
       withHeader
       headerProps={{
         title: 'Bio by AI',
@@ -12,21 +13,18 @@ const BioByAI = function BioByAI() {
         iconColor: 'primary',
       }}
     >
-      <CardContent>
-        <Typography paragraph>
-          Senator Pete Ricketts, a Republican, is the junior senator from
-          Nebraska, appointed on January 23, 2023. He is up for reelection in
-          2024. Ricketts strongly advocates for Taiwan’s security. He
-          co-sponsored the BOLSTER Act to facilitate U.S.-made defense equipment
-          transfers from European NATO countries to Taiwan and promote
-          coordinated sanctions against China. He supports strengthening
-          economic and political ties between Taiwan, the U.S., and Europe,
-          focusing on Taiwan’s integration into international organizations and
-          economic resilience, especially in semiconductors. Ricketts also
-          emphasizes humanitarian aid for Taiwan and counters Chinese propaganda
-          to support Taiwan’s democracy.
-        </Typography>
-      </CardContent>
+      <Typography component="p">
+        Senator Pete Ricketts, a Republican, is the junior senator from
+        Nebraska, appointed on January 23, 2023. He is up for reelection in
+        2024. Ricketts strongly advocates for Taiwan’s security. He co-sponsored
+        the BOLSTER Act to facilitate U.S.-made defense equipment transfers from
+        European NATO countries to Taiwan and promote coordinated sanctions
+        against China. He supports strengthening economic and political ties
+        between Taiwan, the U.S., and Europe, focusing on Taiwan’s integration
+        into international organizations and economic resilience, especially in
+        semiconductors. Ricketts also emphasizes humanitarian aid for Taiwan and
+        counters Chinese propaganda to support Taiwan’s democracy.
+      </Typography>
     </UContentCard>
   )
 }

--- a/src/modules/People/components/PeopleTracker/CardContent/Committee.tsx
+++ b/src/modules/People/components/PeopleTracker/CardContent/Committee.tsx
@@ -1,8 +1,6 @@
 import { PeopleIcon } from '@/common/styles/assets/Icons'
 import { CardContent, Stack, Typography, useTheme } from '@mui/material'
-import UIconButton from '@/common/components/atoms/UIconButton'
 import { styled, USTWTheme } from '@/common/lib/mui/theme'
-import ArrowForwardIcon from '@mui/icons-material/ArrowForward'
 import UContentCard from '@/common/components/atoms/UContentCard'
 
 const MOCK_COMMITTEES = [
@@ -100,8 +98,6 @@ interface CommitteeProps {
 const Committee = function Committee({
   committees = MOCK_COMMITTEES,
 }: CommitteeProps) {
-  const theme = useTheme<USTWTheme>()
-
   return (
     <UContentCard
       withHeader
@@ -109,11 +105,6 @@ const Committee = function Committee({
         title: 'Committee',
         icon: <PeopleIcon />,
         iconColor: 'secondary',
-        action: (
-          <UIconButton variant="rounded" color="inherit" size="small">
-            <ArrowForwardIcon sx={{ color: theme.color.neutral[500] }} />
-          </UIconButton>
-        ),
       }}
     >
       <CardContent

--- a/src/modules/People/components/PeopleTracker/CardContent/Experience.tsx
+++ b/src/modules/People/components/PeopleTracker/CardContent/Experience.tsx
@@ -219,6 +219,7 @@ const Experience = function Experience({ experience }: ExperienceProps) {
         icon: <BriefcaseIcon />,
         iconColor: 'primary',
       }}
+      overflowHidden
     >
       {experience?.map((exp, index) => (
         <ExperienceRow key={index} experience={exp} />

--- a/src/modules/People/components/PeopleTracker/CardContent/Experience.tsx
+++ b/src/modules/People/components/PeopleTracker/CardContent/Experience.tsx
@@ -1,9 +1,6 @@
 import { BriefcaseIcon } from '@/common/styles/assets/Icons'
-import { CardContent, Stack, Typography, useTheme } from '@mui/material'
-import ArrowForwardIcon from '@mui/icons-material/ArrowForward'
-import UIconButton from '@/common/components/atoms/UIconButton'
+import { Stack, Typography, useTheme } from '@mui/material'
 import { USTWTheme } from '@/common/lib/mui/theme'
-import CloseIcon from '@mui/icons-material/Close'
 import { useMemo } from 'react'
 import {
   type Experience as PeopleExperience,
@@ -16,8 +13,6 @@ import TimelineConnector from '@mui/lab/TimelineConnector'
 import TimelineContent from '@mui/lab/TimelineContent'
 import TimelineDot from '@mui/lab/TimelineDot'
 import UContentCard from '@/common/components/atoms/UContentCard'
-import UContentCardDialog from '@/common/components/atoms/UContentCardDialog'
-import useModal from '@/common/hooks/useModal'
 
 /**
  * 計算經歷的時間
@@ -205,14 +200,6 @@ interface ExperienceProps {
    * 人物經歷
    */
   experience: PeopleExperience[]
-  /**
-   * 是否是彈窗
-   */
-  isModal?: boolean
-  /**
-   * 點擊事件
-   */
-  onActionClick?: () => void
 }
 
 /**
@@ -222,71 +209,20 @@ interface ExperienceProps {
  * @param onActionClick 點擊事件
  * @returns 人物經歷元件
  */
-const Experience = function Experience({
-  experience,
-  isModal,
-  onActionClick,
-}: ExperienceProps) {
-  const theme = useTheme<USTWTheme>()
-  const { isModalOpen, handleOpenModal, handleCloseModal } = useModal()
-
-  const handleActionClick = () => {
-    if (!isModal) {
-      handleOpenModal()
-    } else {
-      onActionClick?.()
-    }
-  }
-
+const Experience = function Experience({ experience }: ExperienceProps) {
   return (
     <UContentCard
+      headerIconAction="modal"
       withHeader
       headerProps={{
         title: 'Experience',
         icon: <BriefcaseIcon />,
         iconColor: 'primary',
-        action: (
-          <UIconButton
-            variant="rounded"
-            color="inherit"
-            size="small"
-            onClick={handleActionClick}
-          >
-            {isModal ? (
-              <CloseIcon sx={{ color: theme.color.neutral[500] }} />
-            ) : (
-              <ArrowForwardIcon sx={{ color: theme.color.neutral[500] }} />
-            )}
-          </UIconButton>
-        ),
       }}
-      sx={{
-        ...(isModal && {
-          padding: 0,
-          border: 'none',
-          borderRadius: 0,
-        }),
-      }}
-      overflowHidden={!isModal}
     >
-      <CardContent
-        sx={{
-          padding: 0,
-        }}
-      >
-        {experience?.map((exp, index) => (
-          <ExperienceRow key={index} experience={exp} />
-        ))}
-      </CardContent>
-      {isModalOpen && (
-        <UContentCardDialog open={isModalOpen} onClose={handleCloseModal}>
-          <Experience
-            isModal
-            onActionClick={handleCloseModal}
-            experience={experience}
-          />
-        </UContentCardDialog>
-      )}
+      {experience?.map((exp, index) => (
+        <ExperienceRow key={index} experience={exp} />
+      ))}
     </UContentCard>
   )
 }

--- a/src/modules/People/components/PeopleTracker/CardContent/IdeologyLeadershipChart.tsx
+++ b/src/modules/People/components/PeopleTracker/CardContent/IdeologyLeadershipChart.tsx
@@ -1,27 +1,17 @@
 import { LineChartIcon } from '@/common/styles/assets/Icons'
-import { useTheme } from '@mui/material'
-import UIconButton from '@/common/components/atoms/UIconButton'
-import { USTWTheme } from '@/common/lib/mui/theme'
-import ArrowForwardIcon from '@mui/icons-material/ArrowForward'
 import UContentCard from '@/common/components/atoms/UContentCard'
 import IdeologyLeadershipChartElement from '@/common/components/elements/IdeologyLeadershipChart'
 import data from '@/modules/People/assets/data/ideology.json'
 
 const IdeologyLeadershipChart = function IdeologyLeadershipChart() {
-  const theme = useTheme<USTWTheme>()
-
   return (
     <UContentCard
+      headerIconAction="modal"
       withHeader
       headerProps={{
         title: 'Ideology-Leadership Chart',
         icon: <LineChartIcon />,
         iconColor: 'secondary',
-        action: (
-          <UIconButton variant="rounded" color="inherit" size="small">
-            <ArrowForwardIcon sx={{ color: theme.color.neutral[500] }} />
-          </UIconButton>
-        ),
       }}
     >
       <IdeologyLeadershipChartElement activeId={'412190'} data={data} />

--- a/src/modules/People/components/PeopleTracker/CardContent/Publication.tsx
+++ b/src/modules/People/components/PeopleTracker/CardContent/Publication.tsx
@@ -122,6 +122,7 @@ const Publication = function Publication({
           simplified={false}
         />
       ))}
+      overflowHidden
     >
       {publications.map((publication, index) => (
         <PublicationRow

--- a/src/modules/People/components/PeopleTracker/CardContent/Publication.tsx
+++ b/src/modules/People/components/PeopleTracker/CardContent/Publication.tsx
@@ -1,12 +1,7 @@
 import { DocumentIcon } from '@/common/styles/assets/Icons'
-import { CardContent, Stack, Typography, useTheme } from '@mui/material'
-import UIconButton from '@/common/components/atoms/UIconButton'
+import { Stack, Typography, useTheme } from '@mui/material'
 import { USTWTheme } from '@/common/lib/mui/theme'
-import ArrowForwardIcon from '@mui/icons-material/ArrowForward'
-import CloseIcon from '@mui/icons-material/Close'
 import UContentCard from '@/common/components/atoms/UContentCard'
-import UContentCardDialog from '@/common/components/atoms/UContentCardDialog'
-import useModal from '@/common/hooks/useModal'
 
 type PublicationArg = {
   title: string
@@ -100,14 +95,6 @@ interface PublicationProps {
    * 出版品
    */
   publications?: Array<PublicationArg>
-  /**
-   * 是否是彈窗
-   */
-  isModal?: boolean
-  /**
-   * 點擊事件
-   */
-  onActionClick?: () => void
 }
 
 /**
@@ -118,73 +105,31 @@ interface PublicationProps {
  */
 const Publication = function Publication({
   publications = MOCK_PUBLICATIONS,
-  isModal,
-  onActionClick,
 }: PublicationProps) {
-  const theme = useTheme<USTWTheme>()
-  const { isModalOpen, handleOpenModal, handleCloseModal } = useModal()
-
-  const handleActionClick = () => {
-    if (!isModal) {
-      handleOpenModal()
-    } else {
-      onActionClick?.()
-    }
-  }
-
   return (
     <UContentCard
+      headerIconAction="modal"
       withHeader
       headerProps={{
         title: 'Publication',
         icon: <DocumentIcon />,
         iconColor: 'primary',
-        action: (
-          <UIconButton
-            variant="rounded"
-            color="inherit"
-            size="small"
-            onClick={handleActionClick}
-          >
-            {isModal ? (
-              <CloseIcon sx={{ color: theme.color.neutral[500] }} />
-            ) : (
-              <ArrowForwardIcon sx={{ color: theme.color.neutral[500] }} />
-            )}
-          </UIconButton>
-        ),
       }}
-      sx={{
-        ...(isModal && {
-          padding: 0,
-          border: 'none',
-          borderRadius: 0,
-        }),
-      }}
-      overflowHidden={!isModal}
+      modalContent={publications.map((publication, index) => (
+        <PublicationRow
+          key={index}
+          publication={publication}
+          simplified={false}
+        />
+      ))}
     >
-      <CardContent
-        sx={{
-          padding: 0,
-        }}
-      >
-        {publications.map((publication, index) => (
-          <PublicationRow
-            key={index}
-            publication={publication}
-            simplified={!isModal}
-          />
-        ))}
-      </CardContent>
-      {isModalOpen && (
-        <UContentCardDialog open={isModalOpen} onClose={handleCloseModal}>
-          <Publication
-            isModal
-            onActionClick={handleCloseModal}
-            publications={publications}
-          />
-        </UContentCardDialog>
-      )}
+      {publications.map((publication, index) => (
+        <PublicationRow
+          key={index}
+          publication={publication}
+          simplified={true}
+        />
+      ))}
     </UContentCard>
   )
 }

--- a/src/modules/People/components/PeopleTracker/CardContent/VotesWithParty.tsx
+++ b/src/modules/People/components/PeopleTracker/CardContent/VotesWithParty.tsx
@@ -1,11 +1,10 @@
 import { PeopleCheckIcon } from '@/common/styles/assets/Icons'
-import { Box, CardContent, Stack, Typography, useTheme } from '@mui/material'
+import { Box, Stack, Typography, useTheme } from '@mui/material'
 import { USTWTheme } from '@/common/lib/mui/theme'
 import { PieChart, PieChartProps } from '@mui/x-charts'
 import type React from 'react'
 import { useMemo } from 'react'
 import UContentCard from '@/common/components/atoms/UContentCard'
-import UCardInfo from '@/common/components/atoms/UCardInfo'
 
 // TODO: 確認比例來源
 const MOCK_VOTES_WITH_PARTY_PERCENTAGE = 96.12345
@@ -65,45 +64,42 @@ const VotesWithParty = function VotesWithParty() {
         title: 'Votes with Party',
         icon: <PeopleCheckIcon />,
         iconColor: 'secondary',
-        action: <UCardInfo content="Votes" />,
       }}
     >
-      <CardContent sx={{ padding: 0 }}>
-        <Stack spacing={2} alignItems="center" justifyContent="center">
-          <Box
-            width={220}
-            height={220}
-            display="flex"
-            alignItems="center"
-            justifyContent="center"
-            position="relative"
-          >
-            <PieChart
-              series={[
-                {
-                  data,
-                  innerRadius: 70,
-                  outerRadius: 90,
-                },
-              ]}
-              width={200}
-              height={200}
-              margin={{ top: 0, right: 0, bottom: 0, left: 0 }}
-              slotProps={{
-                legend: { hidden: true },
-              }}
-              sx={{
-                overflow: 'visible',
-              }}
-            />
-            <PieCenterLabel value={percentage} />
-          </Box>
-          <Typography variant="subtitleM" fontWeight={400} textAlign="center">
-            This statistical data comes from the records of the current
-            Parliament.
-          </Typography>
-        </Stack>
-      </CardContent>
+      <Stack spacing={2} alignItems="center" justifyContent="center">
+        <Box
+          width={220}
+          height={220}
+          display="flex"
+          alignItems="center"
+          justifyContent="center"
+          position="relative"
+        >
+          <PieChart
+            series={[
+              {
+                data,
+                innerRadius: 70,
+                outerRadius: 90,
+              },
+            ]}
+            width={200}
+            height={200}
+            margin={{ top: 0, right: 0, bottom: 0, left: 0 }}
+            slotProps={{
+              legend: { hidden: true },
+            }}
+            sx={{
+              overflow: 'visible',
+            }}
+          />
+          <PieCenterLabel value={percentage} />
+        </Box>
+        <Typography variant="subtitleM" fontWeight={400} textAlign="center">
+          This statistical data comes from the records of the current
+          Parliament.
+        </Typography>
+      </Stack>
     </UContentCard>
   )
 }

--- a/src/modules/People/components/PeopleTracker/PeopleContentSection.tsx
+++ b/src/modules/People/components/PeopleTracker/PeopleContentSection.tsx
@@ -6,7 +6,6 @@ import IdeologyLeadershipChart from '@/modules/People/components/PeopleTracker/C
 import NumberLink from '@/modules/People/components/PeopleTracker/CardContent/NumberLink'
 import Party from '@/modules/People/components/PeopleTracker/CardContent/Party'
 import Publication from '@/modules/People/components/PeopleTracker/CardContent/Publication'
-import VotesWithParty from '@/modules/People/components/PeopleTracker/CardContent/VotesWithParty'
 import { Box, Grid2 as Grid, useTheme } from '@mui/material'
 import { memo } from 'react'
 
@@ -51,11 +50,6 @@ const PeopleContentSection = memo(function PeopleContentSection({
 
         <Grid size={5}>
           <Experience experience={people.experience ?? []} />
-        </Grid>
-
-        {/** Row 2 */}
-        <Grid size={3}>
-          <VotesWithParty />
         </Grid>
 
         <Grid size={4.5}>


### PR DESCRIPTION
## Summary

許多地方使用 UContentCard 會 reuse 開 Modal 相關實作，未來也會有很多 Tooltip 相關實作。
把相關實作移到 UContentCard。

~TODO: Tooltip~

## Test Plan


https://github.com/user-attachments/assets/ac50e254-4f3c-48d0-b857-0c5382b7b46c

tooltip

https://github.com/user-attachments/assets/88c043bb-a024-4ea0-93bc-1f5d08dea104




## Task

