### PR TITLE
fix: fix header scroll bug & carousel select events

### DIFF
--- a/src/app/[lang]/global.css
+++ b/src/app/[lang]/global.css
@@ -2,6 +2,10 @@
  * 全域樣式
  */
 
+body {
+  overflow-x: hidden;
+}
+
 /** 移除 user agent 樣式 */
 a {
   text-decoration: none;

--- a/src/common/components/elements/Carousel/index.tsx
+++ b/src/common/components/elements/Carousel/index.tsx
@@ -14,6 +14,7 @@ const StyledCarouselContainer = styled(Stack)(() => ({
   width: '100%',
   '& .slick-slider': {
     width: '100%',
+    userSelect: 'text',
   },
 }))
 
@@ -118,3 +119,16 @@ function Carousel({
 }
 
 export default Carousel
+
+export const withSelectable = <T extends object>(
+  Component: React.ComponentType<T>
+) => {
+  return function WithSelectable(props: T) {
+    return (
+      <Component
+        {...props}
+        onMouseDown={(e: React.MouseEvent) => e.stopPropagation()}
+      />
+    )
+  }
+}

--- a/src/common/components/elements/Carousel/index.tsx
+++ b/src/common/components/elements/Carousel/index.tsx
@@ -119,16 +119,3 @@ function Carousel({
 }
 
 export default Carousel
-
-export const withSelectable = <T extends object>(
-  Component: React.ComponentType<T>
-) => {
-  return function WithSelectable(props: T) {
-    return (
-      <Component
-        {...props}
-        onMouseDown={(e: React.MouseEvent) => e.stopPropagation()}
-      />
-    )
-  }
-}

--- a/src/common/components/elements/Header/index.tsx
+++ b/src/common/components/elements/Header/index.tsx
@@ -14,6 +14,7 @@ import SearchBar from '@/modules/Search/components/SearchBar'
 import { ProfileIcon, SearchIcon } from '@/common/styles/assets/Icons'
 import { ROUTES } from '@/routes'
 import { useRouter } from 'next/navigation'
+import useFreezeScreen from '@/common/hooks/useFreezeScreen'
 
 interface HeaderProps {
   className?: string
@@ -128,6 +129,7 @@ const StyledNavMenu = styled(Menu)(({ theme }) => ({
 }))
 
 const Header = ({ className, onProfileClick, onSearchClick }: HeaderProps) => {
+  const { freezeScreen, unfreezeScreen } = useFreezeScreen()
   const router = useRouter()
   const { navItems } = useNavItems()
   const [menuOpenNavItem, setMenuOpenNavItem] = useState<HeaderNavItem | null>(
@@ -144,10 +146,14 @@ const Header = ({ className, onProfileClick, onSearchClick }: HeaderProps) => {
   ) => {
     setNavItemAnchorEl(event.currentTarget)
     setMenuOpenNavItem(item)
+
+    freezeScreen()
   }
   const handleNavMenuClose = () => {
     setNavItemAnchorEl(null)
     setMenuOpenNavItem(null)
+
+    unfreezeScreen()
   }
 
   const headerRef = useRef<HTMLHeadElement>(null)
@@ -236,6 +242,11 @@ const Header = ({ className, onProfileClick, onSearchClick }: HeaderProps) => {
                       vertical: 'bottom',
                       horizontal: 'center',
                     }}
+                    /**
+                     * 避免 menu 被 header 遮擋，做出 header 與 menu 重疊的效果
+                     * 但同時會導致 menu 的 overlay 不為 body 的 第一層 children
+                     * 因此需要將 body 固定
+                     */
                     container={headerRef.current}
                   >
                     {menuOpenNavItem?.list.map((subItem) => (

--- a/src/common/components/elements/IndexKvCard/index.tsx
+++ b/src/common/components/elements/IndexKvCard/index.tsx
@@ -7,7 +7,7 @@ import { styled } from '@/common/lib/mui/theme'
 import UButton from '@/common/components/atoms/UButton'
 import Link from 'next/link'
 import ArrowForwardIcon from '@mui/icons-material/ArrowForward'
-import { withSelectable } from '@/common/components/elements/Carousel'
+import withSelectable from '@/common/hooks/withSelectable'
 
 const StyledIndexKvCardContainer = styled(Box)(({ theme }) => ({
   backgroundColor: theme.palette.primary.main,

--- a/src/common/components/elements/IndexKvCard/index.tsx
+++ b/src/common/components/elements/IndexKvCard/index.tsx
@@ -1,15 +1,15 @@
 'use client'
 
-import { memo } from 'react'
-import { Box, Stack, Typography } from '@mui/material'
+import { ComponentProps, memo } from 'react'
+import { Box, Stack, StackProps, Typography } from '@mui/material'
 import Image from 'next/image'
 import { styled } from '@/common/lib/mui/theme'
 import UButton from '@/common/components/atoms/UButton'
 import Link from 'next/link'
 import ArrowForwardIcon from '@mui/icons-material/ArrowForward'
+import { withSelectable } from '@/common/components/elements/Carousel'
 
 const StyledIndexKvCardContainer = styled(Box)(({ theme }) => ({
-  width: '100%',
   backgroundColor: theme.palette.primary.main,
   padding: theme.spacing(2, 2, 2, 4),
   borderRadius: '30px',
@@ -31,6 +31,8 @@ const StyledImage = styled(Image)(() => ({
 const StyledLeftSection = styled(Stack)(({ theme }) => ({
   padding: theme.spacing(2, 0),
 }))
+const StyledLeftSectionWithSelectable =
+  withSelectable<StackProps>(StyledLeftSection)
 
 const StyledMiddleSection = styled(Stack)(({ theme }) => ({
   margin: theme.spacing(4, 0),
@@ -54,6 +56,7 @@ const StyledDescriptionTypography = styled(Typography)(() => ({
 
 // TODO: 確認類型
 interface IndexKvCardProps {
+  containerSx?: ComponentProps<typeof StyledIndexKvCardContainer>['sx']
   tags: Array<string>
   title: string
   description: string
@@ -63,9 +66,9 @@ interface IndexKvCardProps {
 
 const IndexKvCard = memo(function IndexKvCard(props: IndexKvCardProps) {
   return (
-    <StyledIndexKvCardContainer>
+    <StyledIndexKvCardContainer sx={props.containerSx}>
       <Stack direction="row" spacing={8}>
-        <StyledLeftSection direction="column" spacing={4}>
+        <StyledLeftSectionWithSelectable direction="column" spacing={4}>
           {/** Tags */}
           <Stack direction="row" spacing={1}>
             {props.tags.map((tag, index) => (
@@ -86,7 +89,7 @@ const IndexKvCard = memo(function IndexKvCard(props: IndexKvCardProps) {
           </StyledMiddleSection>
 
           {/** Learn More Button */}
-          <Link href={props.href}>
+          <Link href={props.href} style={{ width: 'fit-content' }}>
             <UButton
               variant="contained"
               color="info"
@@ -97,7 +100,7 @@ const IndexKvCard = memo(function IndexKvCard(props: IndexKvCardProps) {
               Learn More
             </UButton>
           </Link>
-        </StyledLeftSection>
+        </StyledLeftSectionWithSelectable>
         <StyledImage
           src={props.image}
           alt={props.title}

--- a/src/common/components/elements/IndexKvCards/index.tsx
+++ b/src/common/components/elements/IndexKvCards/index.tsx
@@ -3,15 +3,19 @@
 import UFullWidthBackgroundBox from '@/common/components/atoms/UFullWidthBackgroundBox'
 import Carousel from '@/common/components/elements/Carousel'
 import IndexKvCard from '@/common/components/elements/IndexKvCard'
+import { USTWTheme } from '@/common/lib/mui/theme'
 import { ROUTES } from '@/routes'
-import { Container } from '@mui/material'
+import { Container, useTheme } from '@mui/material'
 
 const IndexKVCards = () => {
+  const theme = useTheme<USTWTheme>()
+
   return (
     <UFullWidthBackgroundBox>
       <Container>
         <Carousel>
           <IndexKvCard
+            containerSx={{ margin: theme.spacing(0, 1) }}
             tags={['#1', '#2', '#3']}
             title="快訊：美國政府宣布提供台灣 8000 萬美元外國軍事融資"
             description="美國時間8/30日，美聯社報導美國政府已正式通知國會，將向台灣提供8000萬美元「無償軍事援助」。去年底通過的2023財政年度國防授權法案（NDAA FY2023）中有一項「台灣增強韌性法案」（Taiwan Enhanced Resilience Act），授權美國國務院從2023年至2027年期間，每年提供台灣高達20億美元的軍援...美國時間8/30日，美聯社報導美國政府已正式通知國會，將向台灣提供8000萬美元「無償軍事援助」。去年底通過的2023財政年度國防授權法案（NDAA FY2023）中有一項「台灣增強韌性法案」（Taiwan Enhanced Resilience Act），授權美國國務院從2023年至2027年期間，每年提供台灣高達20億美元的軍援..."
@@ -19,6 +23,7 @@ const IndexKVCards = () => {
             href={ROUTES.BILL}
           />
           <IndexKvCard
+            containerSx={{ margin: theme.spacing(0, 1) }}
             tags={['#1', '#2', '#3']}
             title="快訊：美國政府宣布提供台灣 8000 萬美元外國軍事融資"
             description="美國時間8/30日，美聯社報導美國政府已正式通知國會，將向台灣提供8000萬美元「無償軍事援助」。去年底通過的2023財政年度國防授權法案（NDAA FY2023）中有一項「台灣增強韌性法案」（Taiwan Enhanced Resilience Act），授權美國國務院從2023年至2027年期間，每年提供台灣高達20億美元的軍援...美國時間8/30日，美聯社報導美國政府已正式通知國會，將向台灣提供8000萬美元「無償軍事援助」。去年底通過的2023財政年度國防授權法案（NDAA FY2023）中有一項「台灣增強韌性法案」（Taiwan Enhanced Resilience Act），授權美國國務院從2023年至2027年期間，每年提供台灣高達20億美元的軍援..."
@@ -26,6 +31,7 @@ const IndexKVCards = () => {
             href={ROUTES.BILL}
           />
           <IndexKvCard
+            containerSx={{ margin: theme.spacing(0, 1) }}
             tags={['#1', '#2', '#3']}
             title="快訊：美國政府宣布提供台灣 8000 萬美元外國軍事融資"
             description="美國時間8/30日，美聯社報導美國政府已正式通知國會，將向台灣提供8000萬美元「無償軍事援助」。去年底通過的2023財政年度國防授權法案（NDAA FY2023）中有一項「台灣增強韌性法案」（Taiwan Enhanced Resilience Act），授權美國國務院從2023年至2027年期間，每年提供台灣高達20億美元的軍援...美國時間8/30日，美聯社報導美國政府已正式通知國會，將向台灣提供8000萬美元「無償軍事援助」。去年底通過的2023財政年度國防授權法案（NDAA FY2023）中有一項「台灣增強韌性法案」（Taiwan Enhanced Resilience Act），授權美國國務院從2023年至2027年期間，每年提供台灣高達20億美元的軍援..."

--- a/src/common/hooks/useFreezeScreen.ts
+++ b/src/common/hooks/useFreezeScreen.ts
@@ -1,0 +1,13 @@
+import { useCallback } from 'react'
+
+export default function useFreezeScreen() {
+  const freezeScreen = useCallback(() => {
+    document.body.style.overflow = 'hidden'
+  }, [])
+
+  const unfreezeScreen = useCallback(() => {
+    document.body.style.overflow = ''
+  }, [])
+
+  return { freezeScreen, unfreezeScreen }
+}

--- a/src/common/hooks/withSelectable.tsx
+++ b/src/common/hooks/withSelectable.tsx
@@ -1,0 +1,14 @@
+import type React from 'react'
+
+export default function withSelectable<T extends object>(
+  Component: React.ComponentType<T>
+) {
+  return function WithSelectable(props: T) {
+    return (
+      <Component
+        {...props}
+        onMouseDown={(e: React.MouseEvent) => e.stopPropagation()}
+      />
+    )
+  }
+}

--- a/src/common/lib/mui/theme.ts
+++ b/src/common/lib/mui/theme.ts
@@ -366,6 +366,9 @@ const _lightTheme: USTWThemeOptions = {
   },
   components: {
     MuiButton: {
+      defaultProps: {
+        disableRipple: true,
+      },
       styleOverrides: {
         root: {
           boxShadow: 'none',
@@ -417,6 +420,9 @@ const _ketagalanTheme: USTWThemeOptions = {
   },
   components: {
     MuiButton: {
+      defaultProps: {
+        disableRipple: true,
+      },
       styleOverrides: {
         root: {
           boxShadow: 'none',


### PR DESCRIPTION
## Summary

- 修正 header nav item 打開後會出現滾動 bug，MUI 原生 menu item 實作會用 body 的 overlay 不給使用者滾動，但因為設計上我們需要把 nav item 蓋在 header 之下，因此需要把 menu item 用 portal 實作在 header 那層，會導致可以滾動，因此用 freeze screen hook 凍住
- carousel 使用 `withSelectable` 可以讓使用者可以選取文字

## Test Plan


https://github.com/user-attachments/assets/ff6f4953-ddef-4671-ae04-01d6603a0480



## Task

https://dev.azure.com/ustw/US%20Taiwan%20Watch/_workitems/edit/119/
https://dev.azure.com/ustw/US%20Taiwan%20Watch/_workitems/edit/117/
https://dev.azure.com/ustw/US%20Taiwan%20Watch/_workitems/edit/116/
https://dev.azure.com/ustw/US%20Taiwan%20Watch/_workitems/edit/114/