### PR TITLE
fix: tooltip content

### DIFF
--- a/src/modules/Bill/components/BillCard.tsx
+++ b/src/modules/Bill/components/BillCard.tsx
@@ -13,8 +13,8 @@ import dayjs from 'dayjs'
 import { useMemo } from 'react'
 import { billStatusList } from '@/modules/Bill/constants'
 import UCategoryTag from '@/common/components/atoms/UCategoryTag'
-import { useRouter } from 'next/navigation'
 import UCardInfo from '@/common/components/atoms/UCardInfo'
+import Link from 'next/link'
 
 const DATE_FORMAT = 'MM/DD/YYYY-hh:mmA'
 
@@ -42,7 +42,6 @@ type Props = {
 
 export default function BillCard({ mode, simplified, bill }: Props) {
   const theme = useTheme<USTWTheme>()
-  const router = useRouter()
 
   const isHorizontal = useMemo(() => mode === 'horizontal', [mode])
 
@@ -51,10 +50,6 @@ export default function BillCard({ mode, simplified, bill }: Props) {
       height={isHorizontal || simplified ? 'auto' : 500}
       sx={{
         border: isHorizontal ? 'none' : `1px solid ${theme.color.grey[1600]}`,
-        cursor: 'pointer',
-      }}
-      onClick={() => {
-        router.push(bill.link)
       }}
     >
       <UHStack gap={4} alignItems="center">
@@ -70,9 +65,15 @@ export default function BillCard({ mode, simplified, bill }: Props) {
             {`${bill.chamberPrefix} | ${CONGRESS_CURRENT_SESSION_MOCK}th Congress`}
           </Typography>
 
-          <UHeightLimitedText maxLine={4} variant="subtitleL" fontWeight={700}>
-            {bill.title}
-          </UHeightLimitedText>
+          <Link href={bill.link}>
+            <UHeightLimitedText
+              maxLine={4}
+              variant="subtitleL"
+              fontWeight={700}
+            >
+              {bill.title}
+            </UHeightLimitedText>
+          </Link>
 
           {!isHorizontal && (
             <Box mx={-2} mt={4}>

--- a/src/modules/Bill/components/IndexBillCard/LeftSection.tsx
+++ b/src/modules/Bill/components/IndexBillCard/LeftSection.tsx
@@ -48,7 +48,7 @@ export default function LeftSection({ bill }: Props) {
           <Typography variant="articleH4">
             {Bill.GetBillLatestStatus(bill.status ?? BillStatusEnum.INTRODUCED)}
           </Typography>
-          <UCardInfo content="Tracker" />
+          <UCardInfo content={billStatusList[bill.statusIndex].title} />
         </UHStack>
         <Box mx={-6}>
           <UTimeline

--- a/src/modules/Bill/components/IndexBillCard/LeftSection.tsx
+++ b/src/modules/Bill/components/IndexBillCard/LeftSection.tsx
@@ -11,6 +11,7 @@ import { billStatusList } from '@/modules/Bill/constants'
 import UCategoryTag from '@/common/components/atoms/UCategoryTag'
 import { BillStatusEnum } from '@/modules/Bill/enums/BillStatus'
 import UCardInfo from '@/common/components/atoms/UCardInfo'
+import Link from 'next/link'
 
 type Props = {
   bill: Bill
@@ -37,9 +38,11 @@ export default function LeftSection({ bill }: Props) {
           {`${bill.chamberPrefix} | ${CONGRESS_CURRENT_SESSION_MOCK}th Congress`}
         </Typography>
 
-        <UHeightLimitedText maxLine={4} variant="h6" fontWeight={700}>
-          {bill.title}
-        </UHeightLimitedText>
+        <Link href={bill.link}>
+          <UHeightLimitedText maxLine={4} variant="h6" fontWeight={700}>
+            {bill.title}
+          </UHeightLimitedText>
+        </Link>
       </Stack>
 
       <Stack gap={2}>

--- a/src/modules/Bill/components/IndexBillCard/index.tsx
+++ b/src/modules/Bill/components/IndexBillCard/index.tsx
@@ -2,7 +2,6 @@
 import { styled } from '@/common/lib/mui/theme'
 import { Bill } from '@/modules/Bill/classes/Bill'
 import { Grid2, Stack } from '@mui/material'
-import { useRouter } from 'next/navigation'
 import LeftSection from '@/modules/Bill/components/IndexBillCard/LeftSection'
 import RightSection from '@/modules/Bill/components/IndexBillCard/RightSection'
 
@@ -18,17 +17,8 @@ type Props = {
 }
 
 export default function IndexBillCard({ bill }: Props) {
-  const router = useRouter()
-
   return (
-    <StyledCardContainer
-      sx={{
-        cursor: 'pointer',
-      }}
-      onClick={() => {
-        router.push(bill.link)
-      }}
-    >
+    <StyledCardContainer>
       <Grid2 container spacing={6} height="100%">
         <Grid2 size={6}>
           <LeftSection bill={bill} />


### PR DESCRIPTION
## Summary

1. 修正 IndexBillCard tooltip 原先誤植的 content 
2. Bill Card 從點擊整張卡片皆可跳轉，改為點擊 title 才跳轉

## Test Plan

https://github.com/user-attachments/assets/9a2a98a6-99c6-4b19-ad54-fd4c5726c1e3

https://github.com/user-attachments/assets/ad747fdb-ae8e-4022-9575-35f566ceeb1d

## Task

https://dev.azure.com/ustw/US%20Taiwan%20Watch/_workitems/edit/118