### PR TITLE
fix: Global font family fallback & opinion page button width

### DIFF
--- a/src/common/lib/mui/theme.ts
+++ b/src/common/lib/mui/theme.ts
@@ -139,11 +139,13 @@ export const ps = PublicSans({
   subsets: ['latin'],
   display: 'swap',
   fallback: ['Arial', 'sans-serif'],
+  weight: ['300', '400', '500', '600', '700'],
 })
 export const nstc = NotoSansTC({
   subsets: ['latin'],
   display: 'swap',
   fallback: ['Arial', 'sans-serif'],
+  weight: ['300', '400', '500', '600', '700'],
 })
 
 const color = {

--- a/src/common/lib/mui/theme.ts
+++ b/src/common/lib/mui/theme.ts
@@ -138,10 +138,12 @@ declare module '@mui/material/Typography' {
 export const ps = PublicSans({
   subsets: ['latin'],
   display: 'swap',
+  fallback: ['Arial', 'sans-serif'],
 })
 export const nstc = NotoSansTC({
   subsets: ['latin'],
   display: 'swap',
+  fallback: ['Arial', 'sans-serif'],
 })
 
 const color = {

--- a/src/modules/Opinion/components/OpinionLanding/OpinionLandingBannerCard.tsx
+++ b/src/modules/Opinion/components/OpinionLanding/OpinionLandingBannerCard.tsx
@@ -92,7 +92,12 @@ const OpinionLandingBannerCard = function OpinionLandingBannerCard({
             {/** Learn More Button */}
             <Link
               href={opinion.link}
-              style={{ flex: 1, display: 'flex', alignItems: 'flex-end' }}
+              style={{
+                flex: 1,
+                display: 'flex',
+                alignItems: 'flex-end',
+                maxWidth: 'max-content',
+              }}
             >
               <UButton
                 variant="contained"

--- a/src/modules/Opinion/components/OpinionLanding/OpinionLandingBannerCard.tsx
+++ b/src/modules/Opinion/components/OpinionLanding/OpinionLandingBannerCard.tsx
@@ -90,25 +90,26 @@ const OpinionLandingBannerCard = function OpinionLandingBannerCard({
             </StyledMiddleSection>
 
             {/** Learn More Button */}
-            <Link
-              href={opinion.link}
-              style={{
+            <Box
+              sx={{
                 flex: 1,
                 display: 'flex',
                 alignItems: 'flex-end',
                 maxWidth: 'max-content',
               }}
             >
-              <UButton
-                variant="contained"
-                color="info"
-                rounded
-                size="large"
-                endIcon={<ArrowForwardIcon />}
-              >
-                Learn More
-              </UButton>
-            </Link>
+              <Link href={opinion.link}>
+                <UButton
+                  variant="contained"
+                  color="info"
+                  rounded
+                  size="large"
+                  endIcon={<ArrowForwardIcon />}
+                >
+                  Learn More
+                </UButton>
+              </Link>
+            </Box>
           </StyledLeftSectionWithSelectable>
         </Grid>
 


### PR DESCRIPTION
## Summary

Global font family fallback & opinion page button width

TODO: 待確認 fallback 會不會解決 Benson 的問題，我的電腦沒有 fallback 也正常顯示，如果還不正常就需要看是不是 unicode-range 問題

## Test Plan
![CleanShot 2024-10-23 at 23 25 00@2x](https://github.com/user-attachments/assets/70adef4a-ec5c-49d0-bd4b-5302d3b91a62)
![CleanShot 2024-10-23 at 23 25 14@2x](https://github.com/user-attachments/assets/09053e0a-aeac-4ff5-a8ad-884b23edbd9f)

![CleanShot 2024-10-23 at 23 27 01@2x](https://github.com/user-attachments/assets/3d89c0b7-3ba5-4c92-bce7-8efa3a8b66b6)


## Task

https://dev.azure.com/ustw/US%20Taiwan%20Watch/_workitems/edit/167/
https://dev.azure.com/ustw/US%20Taiwan%20Watch/_workitems/edit/166/