### PR TITLE
feat: people conditional layout

### DIFF
--- a/src/common/assets/constants.ts
+++ b/src/common/assets/constants.ts
@@ -1,2 +1,2 @@
-export const CONGRESS_SESSION_MIN = 96
-export const CURRENT_CONGRESS_SESSION = 118
+export const CONGRESS_NUMBER_MIN = 96
+export const CURRENT_CONGRESS_NUMBER = 118

--- a/src/common/classes/Congress.ts
+++ b/src/common/classes/Congress.ts
@@ -1,5 +1,6 @@
 // TODO: 先簡單設計給People使用
 
+import { CURRENT_CONGRESS_NUMBER } from '@/common/assets/constants'
 import { Party } from '@/common/enums/Party'
 import { isMap, isNumber } from 'lodash-es'
 
@@ -52,4 +53,6 @@ export class Congress {
       this.senateDistribution = congress.senateDistribution
     }
   }
+
+  static CurrentCongressNumber = CURRENT_CONGRESS_NUMBER
 }

--- a/src/common/components/atoms/UContentCard.tsx
+++ b/src/common/components/atoms/UContentCard.tsx
@@ -7,6 +7,7 @@ import UIconButton from '@/common/components/atoms/UIconButton'
 import useModal from '@/common/hooks/useModal'
 import { styled, USTWTheme } from '@/common/lib/mui/theme'
 import {
+  Box,
   Card,
   CardContent,
   CardContentProps,
@@ -18,6 +19,26 @@ import ArrowForwardIcon from '@mui/icons-material/ArrowForward'
 import CloseIcon from '@mui/icons-material/Close'
 import UContentCardDialog from '@/common/components/atoms/UContentCardDialog'
 import UCardInfo, { UCardInfoProps } from '@/common/components/atoms/UCardInfo'
+
+const hasNoContent = (node: React.ReactNode) => {
+  return !node || (Array.isArray(node) && node.length === 0)
+}
+
+const NoContentPlaceholder = ({ children }: { children: React.ReactNode }) => {
+  return (
+    <Box
+      sx={{
+        paddingTop: 4,
+        paddingBottom: 4,
+        display: 'flex',
+        justifyContent: 'center',
+        alignItems: 'center',
+      }}
+    >
+      {children}
+    </Box>
+  )
+}
 
 type HeaderIconAction = 'tooltip' | 'modal'
 
@@ -44,6 +65,8 @@ interface UContentCardProps extends CardProps {
   onActionClick?: () => void
   /** Tooltip 相關參數 */
   tooltipProps?: UCardInfoProps
+  /** 沒有內容時的顯示文字 */
+  noContentPlaceholder?: React.ReactNode
 }
 
 const StyledContentCard = styled(Card)(({ theme }) => ({
@@ -96,6 +119,7 @@ const UContentCard = function UContentCard({
   isModal,
   onActionClick,
   tooltipProps,
+  noContentPlaceholder,
   ...rest
 }: UContentCardProps) {
   const theme = useTheme<USTWTheme>()
@@ -159,7 +183,11 @@ const UContentCard = function UContentCard({
         }}
         {...contentProps}
       >
-        {children}
+        {hasNoContent(children) ? (
+          <NoContentPlaceholder>{noContentPlaceholder}</NoContentPlaceholder>
+        ) : (
+          children
+        )}
       </CardContent>
       {headerIconAction === 'modal' && isModalOpen && (
         <UContentCardDialog open={isModalOpen} onClose={handleCloseModal}>
@@ -184,7 +212,13 @@ const UContentCard = function UContentCard({
               borderRadius: 0,
             }}
           >
-            {modalContent || children}
+            {hasNoContent(modalContent) && hasNoContent(children) ? (
+              <NoContentPlaceholder>
+                {noContentPlaceholder}
+              </NoContentPlaceholder>
+            ) : (
+              modalContent || children
+            )}
           </UContentCard>
         </UContentCardDialog>
       )}

--- a/src/modules/People/classes/People.ts
+++ b/src/modules/People/classes/People.ts
@@ -193,4 +193,15 @@ export class People {
 
   // Nov 2022
   static TimeFormat = 'MMM YYYY'
+
+  /**
+   * 判斷是否為現任議員
+   * TODO: 確認怎麼分辨『現任』
+   * @param people
+   * @returns
+   */
+  static IsCurrentMember(people: People) {
+    // FIXME: 確認怎麼分辨『現任』
+    return people.congress?.congressNumber === Congress.CurrentCongressNumber
+  }
 }

--- a/src/modules/People/components/PeopleFilter/schema.ts
+++ b/src/modules/People/components/PeopleFilter/schema.ts
@@ -6,8 +6,8 @@ import {
   PeoplePartyEnum,
 } from '@/modules/People/components/PeopleFilter/enums'
 import {
-  CURRENT_CONGRESS_SESSION,
-  CONGRESS_SESSION_MIN,
+  CURRENT_CONGRESS_NUMBER,
+  CONGRESS_NUMBER_MIN,
 } from '@/common/assets/constants'
 import { KeysOfUnion } from '@/common/types/common'
 
@@ -16,10 +16,10 @@ const congressSchema = z.union([
   z
     .string()
     .transform((val) => parseInt(val, 10))
-    .pipe(z.number().min(CONGRESS_SESSION_MIN).max(CURRENT_CONGRESS_SESSION))
+    .pipe(z.number().min(CONGRESS_NUMBER_MIN).max(CURRENT_CONGRESS_NUMBER))
     .optional(),
   // Maybe number
-  z.number().min(CONGRESS_SESSION_MIN).max(CURRENT_CONGRESS_SESSION).optional(),
+  z.number().min(CONGRESS_NUMBER_MIN).max(CURRENT_CONGRESS_NUMBER).optional(),
 ])
 
 export const senatorSchema = z.object({

--- a/src/modules/People/components/PeopleFilter/usePeopleFilterOptions.ts
+++ b/src/modules/People/components/PeopleFilter/usePeopleFilterOptions.ts
@@ -8,8 +8,8 @@ import {
 import states from '@/common/assets/states'
 import territoriesRegions from '@/common/assets/territories-regions'
 import {
-  CURRENT_CONGRESS_SESSION,
-  CONGRESS_SESSION_MIN,
+  CURRENT_CONGRESS_NUMBER,
+  CONGRESS_NUMBER_MIN,
 } from '@/common/assets/constants'
 
 export type PeopleFilterOption<T> = {
@@ -44,8 +44,8 @@ export default function usePeopleFilterOptions() {
   const congressOptions = useMemo<PeopleFilterOption<number>[]>(
     () =>
       Array.from(
-        { length: CURRENT_CONGRESS_SESSION - CONGRESS_SESSION_MIN + 1 },
-        (_, i) => i + CONGRESS_SESSION_MIN
+        { length: CURRENT_CONGRESS_NUMBER - CONGRESS_NUMBER_MIN + 1 },
+        (_, i) => i + CONGRESS_NUMBER_MIN
       ).map((congress) => ({
         value: congress,
         label: congress.toString(),

--- a/src/modules/People/components/PeopleTracker/CardContent/BioByAI.tsx
+++ b/src/modules/People/components/PeopleTracker/CardContent/BioByAI.tsx
@@ -18,8 +18,19 @@ const BioByAI = function ({ bioByAI }: BioByAIProps) {
       }}
       overflowHidden
       modalContent={<Typography component="p">{bioByAI}</Typography>}
+      noContentPlaceholder={
+        <Typography variant="subtitleXL" fontWeight={400}>
+          No Bio by AI
+        </Typography>
+      }
     >
-      <Typography component="p">{bioByAI}</Typography>
+      {bioByAI ? (
+        <Typography component="p">{bioByAI}</Typography>
+      ) : (
+        <Typography variant="h5" fontWeight={400}>
+          No bio by AI
+        </Typography>
+      )}
     </UContentCard>
   )
 }

--- a/src/modules/People/components/PeopleTracker/CardContent/Committee.tsx
+++ b/src/modules/People/components/PeopleTracker/CardContent/Committee.tsx
@@ -115,6 +115,11 @@ const Committee = function Committee({
       modalContent={committees.map((committee, index) => (
         <CommitteeRow key={index} committee={committee} />
       ))}
+      noContentPlaceholder={
+        <Typography variant="subtitleXL" fontWeight={400}>
+          No Committee
+        </Typography>
+      }
     >
       {committees.map((committee, index) => (
         <CommitteeRow key={index} committee={committee} />

--- a/src/modules/People/components/PeopleTracker/CardContent/Experience.tsx
+++ b/src/modules/People/components/PeopleTracker/CardContent/Experience.tsx
@@ -220,8 +220,13 @@ const Experience = function Experience({ experience }: ExperienceProps) {
         iconColor: 'primary',
       }}
       overflowHidden
+      noContentPlaceholder={
+        <Typography variant="subtitleXL" fontWeight={400}>
+          No experience
+        </Typography>
+      }
     >
-      {experience?.map((exp, index) => (
+      {experience.map((exp, index) => (
         <ExperienceRow key={index} experience={exp} />
       ))}
     </UContentCard>

--- a/src/modules/People/components/PeopleTracker/CardContent/Publication.tsx
+++ b/src/modules/People/components/PeopleTracker/CardContent/Publication.tsx
@@ -110,7 +110,7 @@ const Publication = function Publication({
         icon: <DocumentIcon />,
         iconColor: 'primary',
       }}
-      modalContent={publications.map((publication, index) => (
+      modalContent={publications?.map((publication, index) => (
         <PublicationRow
           key={index}
           publication={publication}
@@ -118,8 +118,13 @@ const Publication = function Publication({
         />
       ))}
       overflowHidden
+      noContentPlaceholder={
+        <Typography variant="subtitleXL" fontWeight={400}>
+          No Publication
+        </Typography>
+      }
     >
-      {publications.map((publication, index) => (
+      {publications?.map((publication, index) => (
         <PublicationRow
           key={index}
           publication={publication}

--- a/src/modules/People/components/PeopleTracker/PeopleContentSection.tsx
+++ b/src/modules/People/components/PeopleTracker/PeopleContentSection.tsx
@@ -9,8 +9,101 @@ import VotingRecord from '@/modules/People/components/PeopleTracker/CardContent/
 import Party from '@/modules/People/components/PeopleTracker/CardContent/Party'
 import Publication from '@/modules/People/components/PeopleTracker/CardContent/Publication'
 import { Grid2 as Grid, GridSize, Stack, useTheme } from '@mui/material'
-import { memo } from 'react'
+import { memo, useMemo } from 'react'
 import type React from 'react'
+import { PeoplePosition } from '@/modules/People/enums/PeoplePosition'
+
+const useSectionLayout = (people: People) => {
+  const isHouseRepresentativeOrSenator = useMemo(
+    () =>
+      !!people.position &&
+      [PeoplePosition.HOUSE_REPRESENTATIVE, PeoplePosition.SENATOR].includes(
+        people.position
+      ),
+    [people.position]
+  )
+
+  /**
+   * 現任眾議員或參議員才會出現政黨
+   * TODO: 確認怎麼分辨『現任』
+   */
+  const hasParty = useMemo(
+    () =>
+      !!people.party &&
+      isHouseRepresentativeOrSenator &&
+      People.IsCurrentMember(people),
+    [people, isHouseRepresentativeOrSenator]
+  )
+
+  /**
+   * 眾議員或參議員才會有贊助法案
+   */
+  const hasSponsored = useMemo(
+    () => isHouseRepresentativeOrSenator,
+    [isHouseRepresentativeOrSenator]
+  )
+
+  /**
+   * 眾議員或參議員才會有共同提案法案
+   */
+  const hasCoSponsored = useMemo(
+    () => isHouseRepresentativeOrSenator,
+    [isHouseRepresentativeOrSenator]
+  )
+
+  /**
+   * 眾議員或參議員才會有投票紀錄
+   */
+  const hasVotingRecord = useMemo(
+    () => isHouseRepresentativeOrSenator,
+    [isHouseRepresentativeOrSenator]
+  )
+
+  /**
+   * 每個人都有 AI 生成的 Bio
+   */
+  const hasBioByAI = useMemo(() => true, [])
+
+  /**
+   * 每個人都有經歷
+   */
+  const hasExperience = useMemo(() => true, [])
+
+  /**
+   * 現任眾議員或參議員才會有委員會
+   * TODO: 確認怎麼分辨『現任』
+   */
+  const hasCommittee = useMemo(
+    () => isHouseRepresentativeOrSenator && People.IsCurrentMember(people),
+    [isHouseRepresentativeOrSenator, people]
+  )
+
+  /**
+   * 每個人都有出版品
+   */
+  const hasPublication = useMemo(() => true, [])
+
+  /**
+   * 現任眾議員或參議員才會有理念領導力圖表
+   * TODO: 確認怎麼分辨『現任』
+   */
+  const hasIdeologyLeadershipChart = useMemo(
+    () => isHouseRepresentativeOrSenator && People.IsCurrentMember(people),
+    [isHouseRepresentativeOrSenator, people]
+  )
+
+  return {
+    hasParty,
+    hasSponsored,
+    hasCoSponsored,
+    hasVotingRecord,
+    hasBioByAI,
+    hasExperience,
+    hasCommittee,
+    hasPublication,
+    hasIdeologyLeadershipChart,
+  }
+}
 
 interface PeopleContentSectionProps {
   people: People
@@ -20,6 +113,17 @@ const PeopleContentSection = memo(function PeopleContentSection({
   people,
 }: PeopleContentSectionProps) {
   const theme = useTheme()
+  const {
+    hasParty,
+    hasSponsored,
+    hasCoSponsored,
+    hasVotingRecord,
+    hasBioByAI,
+    hasExperience,
+    hasCommittee,
+    hasPublication,
+    hasIdeologyLeadershipChart,
+  } = useSectionLayout(people)
 
   /**
    * 內容排版 (Simulate Mansonry Layout)
@@ -38,15 +142,10 @@ const PeopleContentSection = memo(function PeopleContentSection({
     }>
   }> = [
     {
-      visible:
-        !!people.party ||
-        people.experience.length > 0 ||
-        people.sponsoredBills.length > 0 ||
-        people.coSponsoredBills.length > 0 ||
-        people.votingRecord.length > 0,
+      visible: hasParty || hasSponsored || hasCoSponsored || hasVotingRecord,
       components: [
         {
-          visible: !!people.party,
+          visible: hasParty,
           size: 'grow',
           component: (
             <Party
@@ -56,57 +155,57 @@ const PeopleContentSection = memo(function PeopleContentSection({
           ),
         },
         {
-          visible: people.sponsoredBills.length > 0,
+          visible: hasSponsored,
           size: 2,
           component: <Sponsored />,
         },
         {
-          visible: people.coSponsoredBills.length > 0,
+          visible: hasCoSponsored,
           size: 2,
           component: <CoSponsored />,
         },
         {
-          visible: people.votingRecord.length > 0,
+          visible: hasVotingRecord,
           size: 2,
           component: <VotingRecord />,
         },
       ],
     },
     {
-      visible: !!people.bioByAI?.length || people.experience.length > 0,
+      visible: hasBioByAI || hasExperience,
       components: [
         {
-          visible: !!people.bioByAI?.length,
+          visible: hasBioByAI,
           size: 7,
           component: <BioByAI bioByAI={people.bioByAI} />,
         },
         {
-          visible: people.experience.length > 0,
+          visible: hasExperience,
           size: 5,
           component: <Experience experience={people.experience} />,
         },
       ],
     },
     {
-      visible: people.committees.length > 0 || people.publications.length > 0,
+      visible: hasCommittee || hasPublication,
       components: [
         {
-          visible: people.committees.length > 0,
+          visible: hasCommittee,
           size: 'grow',
           component: <Committee />,
         },
         {
-          visible: people.publications.length > 0,
+          visible: hasPublication,
           size: 'grow',
           component: <Publication />,
         },
       ],
     },
     {
-      visible: true,
+      visible: hasIdeologyLeadershipChart,
       components: [
         {
-          visible: true,
+          visible: hasIdeologyLeadershipChart,
           size: 12,
           component: <IdeologyLeadershipChart />,
         },


### PR DESCRIPTION
## Summary

- 更改 constant name: CONGRESS_SESSION -> CONGRESS_NUMBER，Session 是會期不是屆數
- 不同人物種類的 layout 不同: ref: https://dev.azure.com/ustw/US%20Taiwan%20Watch/_wiki/wikis/US-Taiwan-Watch.wiki/16/Person-Detail-Page
- `UContentCard` 沒有 data 的 placeholder

## Test Plan

- 不同人物種類的 layout 不同

現任眾議員或參議員
![CleanShot 2024-10-26 at 16 18 49](https://github.com/user-attachments/assets/b0de758d-0f8c-40d5-83c4-6c1ff557f819)

非現任眾議員或參議員
![CleanShot 2024-10-26 at 16 20 33](https://github.com/user-attachments/assets/14baad12-8270-4e46-a242-c6ea05fd8c87)


其他
![CleanShot 2024-10-26 at 16 19 12](https://github.com/user-attachments/assets/8d591ec4-a734-4f0f-81ce-962b4a331564)

- 沒有 data 的 placeholder

https://github.com/user-attachments/assets/8b3828ab-4c76-4b5e-befc-958b28bade46



## Task

https://dev.azure.com/ustw/US%20Taiwan%20Watch/_workitems/edit/164/