### PR TITLE
feat: 統整 Container 寬度

### DIFF
--- a/src/app/[lang]/bill-list/layout.tsx
+++ b/src/app/[lang]/bill-list/layout.tsx
@@ -3,7 +3,8 @@ import React from 'react'
 import { Language } from '@/common/lib/i18n/types'
 import ThemeProvider from '@/common/lib/mui/themeProvider'
 import { AppRouterCacheProvider } from '@mui/material-nextjs/v13-appRouter'
-import { Container, CssBaseline } from '@mui/material'
+import CssBaseline from '@mui/material/CssBaseline'
+import Container from '@mui/material/Container'
 
 export const metadata: Metadata = {
   title: 'Bill',

--- a/src/app/[lang]/bill/[id]/page.tsx
+++ b/src/app/[lang]/bill/[id]/page.tsx
@@ -1,6 +1,6 @@
 'use client' // for importing mock data
 
-import { Stack } from '@mui/material'
+import Stack from '@mui/material/Stack'
 import BillInfoSection from '@/modules/Bill/components/SingleBill/BillInfoSection'
 import { BILL_DATA_MOCK } from '@/modules/Bill/data'
 import BillListSection from '@/modules/Bill/components/SingleBill/BillListSection'

--- a/src/app/[lang]/bill/layout.tsx
+++ b/src/app/[lang]/bill/layout.tsx
@@ -3,7 +3,8 @@ import React from 'react'
 import { Language } from '@/common/lib/i18n/types'
 import ThemeProvider from '@/common/lib/mui/themeProvider'
 import { AppRouterCacheProvider } from '@mui/material-nextjs/v13-appRouter'
-import { Container, CssBaseline } from '@mui/material'
+import CssBaseline from '@mui/material/CssBaseline'
+import Container from '@mui/material/Container'
 
 export const metadata: Metadata = {
   title: 'Bill',

--- a/src/app/[lang]/bill/page.tsx
+++ b/src/app/[lang]/bill/page.tsx
@@ -1,6 +1,6 @@
 import BillListSection from '@/modules/Bill/components/BillLanding/BillListSection'
 import BillStatisticsSection from '@/modules/Bill/components/BillLanding/BillStatisticsSection'
-import { Stack } from '@mui/material'
+import Stack from '@mui/material/Stack'
 
 export default function Bill() {
   return (

--- a/src/app/[lang]/layout.tsx
+++ b/src/app/[lang]/layout.tsx
@@ -5,7 +5,6 @@ import CssBaseline from '@mui/material/CssBaseline'
 import { Language } from '@/common/lib/i18n/types'
 import ThemeProvider from '@/common/lib/mui/themeProvider'
 import Header from '@/common/components/elements/Header'
-import { Container } from '@mui/material'
 import Footer from '@/common/components/elements/Footer'
 import ScreenSizeHandler from '@/common/components/elements/UnsupportedScreenSize/ScreenSizeHandler'
 
@@ -30,10 +29,8 @@ export default function RootLayout({
           <ThemeProvider lang={params.lang}>
             {/* CssBaseline kickstart an elegant, consistent, and simple baseline to build upon. */}
             <CssBaseline />
-            <Container>
-              <Header />
-              <ScreenSizeHandler>{children}</ScreenSizeHandler>
-            </Container>
+            <Header />
+            <ScreenSizeHandler>{children}</ScreenSizeHandler>
             <Footer />
           </ThemeProvider>
         </AppRouterCacheProvider>

--- a/src/app/[lang]/opinion/[id]/layout.tsx
+++ b/src/app/[lang]/opinion/[id]/layout.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 import { Language } from '@/common/lib/i18n/types'
 import ThemeProvider from '@/common/lib/mui/themeProvider'
 import { AppRouterCacheProvider } from '@mui/material-nextjs/v13-appRouter'
-import { Container, CssBaseline } from '@mui/material'
+import CssBaseline from '@mui/material/CssBaseline'
 
 export const metadata: Metadata = {
   title: 'Opinion Post',
@@ -38,7 +38,7 @@ export default function OpinionPostLayout({
       >
         {/* CssBaseline kickstart an elegant, consistent, and simple baseline to build upon. */}
         <CssBaseline />
-        <Container maxWidth="lg">{children}</Container>
+        {children}
       </ThemeProvider>
     </AppRouterCacheProvider>
   )

--- a/src/app/[lang]/opinion/page.tsx
+++ b/src/app/[lang]/opinion/page.tsx
@@ -5,7 +5,8 @@ import useOpinionStore from '@/common/lib/zustand/hooks/useOpinionStore'
 import OpinionLandingBannerCards from '@/modules/Opinion/components/OpinionLanding/OpinionLandingBannerCards'
 import OpinionPostSection from '@/modules/Opinion/components/OpinionLanding/OpinionPostSection'
 import OpinionNavbar from '@/modules/Opinion/components/OpinionNavbar'
-import { Stack } from '@mui/material'
+import Container from '@mui/material/Container'
+import Stack from '@mui/material/Stack'
 import { useEffect } from 'react'
 
 export default function Opinion() {
@@ -20,12 +21,14 @@ export default function Opinion() {
   }, [fetchCategories, fetchHighlightedCategories])
 
   return (
-    <Stack>
-      <UFullWidthBackgroundBox>
-        <OpinionNavbar />
-      </UFullWidthBackgroundBox>
-      <OpinionLandingBannerCards />
-      <OpinionPostSection />
-    </Stack>
+    <Container maxWidth="lg">
+      <Stack>
+        <UFullWidthBackgroundBox>
+          <OpinionNavbar />
+        </UFullWidthBackgroundBox>
+        <OpinionLandingBannerCards />
+        <OpinionPostSection />
+      </Stack>
+    </Container>
   )
 }

--- a/src/app/[lang]/opinion/search/[categoryId]/layout.tsx
+++ b/src/app/[lang]/opinion/search/[categoryId]/layout.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 import { Language } from '@/common/lib/i18n/types'
 import ThemeProvider from '@/common/lib/mui/themeProvider'
 import { AppRouterCacheProvider } from '@mui/material-nextjs/v13-appRouter'
-import { Container, CssBaseline } from '@mui/material'
+import CssBaseline from '@mui/material/CssBaseline'
 
 export const metadata: Metadata = {
   title: 'Opinion Search Category',
@@ -38,7 +38,7 @@ export default function OpinionSearchCategoryLayout({
       >
         {/* CssBaseline kickstart an elegant, consistent, and simple baseline to build upon. */}
         <CssBaseline />
-        <Container maxWidth="lg">{children}</Container>
+        {children}
       </ThemeProvider>
     </AppRouterCacheProvider>
   )

--- a/src/app/[lang]/opinion/search/[categoryId]/layout.tsx
+++ b/src/app/[lang]/opinion/search/[categoryId]/layout.tsx
@@ -4,7 +4,7 @@ import { Language } from '@/common/lib/i18n/types'
 import ThemeProvider from '@/common/lib/mui/themeProvider'
 import { AppRouterCacheProvider } from '@mui/material-nextjs/v13-appRouter'
 import CssBaseline from '@mui/material/CssBaseline'
-
+import Container from '@mui/material/Container'
 export const metadata: Metadata = {
   title: 'Opinion Search Category',
   description: 'Opinion Search Category',
@@ -38,7 +38,7 @@ export default function OpinionSearchCategoryLayout({
       >
         {/* CssBaseline kickstart an elegant, consistent, and simple baseline to build upon. */}
         <CssBaseline />
-        {children}
+        <Container maxWidth="lg">{children}</Container>
       </ThemeProvider>
     </AppRouterCacheProvider>
   )

--- a/src/app/[lang]/page.tsx
+++ b/src/app/[lang]/page.tsx
@@ -1,6 +1,5 @@
-import Container from '@mui/material/Container'
 import IndexKvCards from '@/common/components/elements/IndexKvCards'
-import { Stack } from '@mui/material'
+import Stack from '@mui/material/Stack'
 import ArticleSection from '@/modules/LandingPage/components/ArticleSection'
 import KetagalanSection from '@/modules/LandingPage/components/KetagalanSection'
 import PodcastSection from '@/modules/LandingPage/components/PodcastSection'
@@ -10,23 +9,21 @@ import { SECTION_OVERLAP_PX } from '@/modules/LandingPage/constants'
 
 export default function Home() {
   return (
-    <Container maxWidth="lg">
-      <Stack alignContent="center" justifyContent="center">
-        <IndexKvCards />
-        <BillSection />
-        <ArticleSection />
-        <Stack
-          sx={{
-            '& > *': {
-              marginTop: `-${SECTION_OVERLAP_PX}px`,
-            },
-          }}
-        >
-          <KetagalanSection />
-          <PodcastSection />
-          <FreeUsageSection />
-        </Stack>
+    <Stack alignContent="center" justifyContent="center">
+      <IndexKvCards />
+      <BillSection />
+      <ArticleSection />
+      <Stack
+        sx={{
+          '& > *': {
+            marginTop: `-${SECTION_OVERLAP_PX}px`,
+          },
+        }}
+      >
+        <KetagalanSection />
+        <PodcastSection />
+        <FreeUsageSection />
       </Stack>
-    </Container>
+    </Stack>
   )
 }

--- a/src/app/[lang]/people/layout.tsx
+++ b/src/app/[lang]/people/layout.tsx
@@ -3,7 +3,8 @@ import React from 'react'
 import { Language } from '@/common/lib/i18n/types'
 import ThemeProvider from '@/common/lib/mui/themeProvider'
 import { AppRouterCacheProvider } from '@mui/material-nextjs/v13-appRouter'
-import { Container, CssBaseline } from '@mui/material'
+import CssBaseline from '@mui/material/CssBaseline'
+import Container from '@mui/material/Container'
 
 export const metadata: Metadata = {
   title: 'People',

--- a/src/common/components/elements/Footer/index.tsx
+++ b/src/common/components/elements/Footer/index.tsx
@@ -11,7 +11,8 @@ import UButton from '@/common/components/atoms/UButton'
 import LanguageSwitcher from '@/common/components/elements/LanguageSwitcher'
 
 const StyledFooter = styled('footer')(({ theme }) => ({
-  padding: `${theme.spacing(2)} ${theme.spacing(4)}`,
+  paddingTop: theme.spacing(4),
+  paddingBottom: theme.spacing(4),
   color: theme.color.grey[1100],
 }))
 
@@ -30,7 +31,7 @@ const Footer = () => {
 
   return (
     <UFullWidthBackgroundBox backgroundColor="common.black">
-      <Container maxWidth="lg">
+      <Container maxWidth="xl">
         <StyledFooter>
           {/** Top Section */}
           <Stack direction="column" spacing={6}>

--- a/src/common/components/elements/Footer/index.tsx
+++ b/src/common/components/elements/Footer/index.tsx
@@ -30,7 +30,7 @@ const Footer = () => {
 
   return (
     <UFullWidthBackgroundBox backgroundColor="common.black">
-      <Container>
+      <Container maxWidth="lg">
         <StyledFooter>
           {/** Top Section */}
           <Stack direction="column" spacing={6}>

--- a/src/common/components/elements/Header/index.tsx
+++ b/src/common/components/elements/Header/index.tsx
@@ -2,7 +2,11 @@
 
 import clsx from 'clsx'
 import ULogo from '@/common/components/atoms/ULogo'
-import { Box, Menu, MenuItem, Typography } from '@mui/material'
+import Box from '@mui/material/Box'
+import Menu from '@mui/material/Menu'
+import MenuItem from '@mui/material/MenuItem'
+import Typography from '@mui/material/Typography'
+import Container from '@mui/material/Container'
 import Link from 'next/link'
 import UButton from '@/common/components/atoms/UButton'
 import UIconButton from '@/common/components/atoms/UIconButton'
@@ -21,10 +25,16 @@ interface HeaderProps {
   onSearchClick?: () => void
 }
 
-const StyledHeader = styled('header')(({ theme }) => ({
+const StyledHeaderContainer = styled(Container)(({ theme }) => ({
   position: 'sticky',
   top: theme.spacing(4.5),
   zIndex: theme.constants.zIndex.header,
+  margin: `${theme.spacing(4.5)} auto`,
+  paddingLeft: `${theme.spacing(3)} !important`,
+  paddingRight: `${theme.spacing(3)} !important`,
+}))
+
+const StyledHeader = styled('header')(({ theme }) => ({
   display: 'flex',
   [theme.breakpoints.up('xs')]: {
     height: `${theme.constants.headerHeight.xs}px`,
@@ -32,13 +42,12 @@ const StyledHeader = styled('header')(({ theme }) => ({
   [theme.breakpoints.up('md')]: {
     height: `${theme.constants.headerHeight.md}px`,
   },
-  margin: `${theme.spacing(4.5)} auto`,
   '& #nav-item-menu': {
     zIndex: theme.constants.zIndex.headerNavItem,
   },
 }))
 
-const StyledHeaderContainer = styled(Box)(({ theme }) => ({
+const StyledHeaderWrapper = styled(Box)(({ theme }) => ({
   position: 'relative',
   zIndex: theme.constants.zIndex.header,
   width: '100%',
@@ -172,139 +181,141 @@ const Header = ({ className, onProfileClick, onSearchClick }: HeaderProps) => {
   }
 
   return (
-    <StyledHeader ref={headerRef} onClick={handleNavMenuClose}>
-      <StyledHeaderContainer
-        className={className}
-        display="flex"
-        alignItems="center"
-        justifyContent="space-between"
-        gap={2}
-      >
-        {/** 左側 */}
-        <Box
+    <StyledHeaderContainer maxWidth="lg">
+      <StyledHeader ref={headerRef} onClick={handleNavMenuClose}>
+        <StyledHeaderWrapper
+          className={className}
           display="flex"
           alignItems="center"
-          gap={1}
-          sx={{ cursor: 'pointer' }}
-          onClick={() => {
-            router.push(ROUTES.HOME)
-          }}
+          justifyContent="space-between"
+          gap={2}
         >
-          <ULogo size="small" />
-          <Typography fontWeight={700}>USTW</Typography>
-        </Box>
-        {isSearchOpen ? (
-          <SearchBar
-            resultParentEl={headerRef.current}
-            onClickAway={handleSearchClose}
-          />
-        ) : (
-          <>
-            {/** 中間 */}
-            <Box height="100%" display="flex" alignItems="center" gap={1}>
-              {navItems.map((item) =>
-                item.type === 'link' ? (
-                  <Link href={item.href} key={item.id}>
+          {/** 左側 */}
+          <Box
+            display="flex"
+            alignItems="center"
+            gap={1}
+            sx={{ cursor: 'pointer' }}
+            onClick={() => {
+              router.push(ROUTES.HOME)
+            }}
+          >
+            <ULogo size="small" />
+            <Typography fontWeight={700}>USTW</Typography>
+          </Box>
+          {isSearchOpen ? (
+            <SearchBar
+              resultParentEl={headerRef.current}
+              onClickAway={handleSearchClose}
+            />
+          ) : (
+            <>
+              {/** 中間 */}
+              <Box height="100%" display="flex" alignItems="center" gap={1}>
+                {navItems.map((item) =>
+                  item.type === 'link' ? (
+                    <Link href={item.href} key={item.id}>
+                      <UButton
+                        className={clsx('nav-item', {
+                          active: item.id === menuOpenNavItem?.id,
+                        })}
+                        variant="text"
+                        key={item.id}
+                      >
+                        {item.title}
+                      </UButton>
+                    </Link>
+                  ) : (
                     <UButton
-                      className={clsx('nav-item', {
+                      className={clsx('nav-item nav-button', {
                         active: item.id === menuOpenNavItem?.id,
                       })}
+                      id={`nav-button-${item.id}`}
                       variant="text"
                       key={item.id}
+                      endIcon={<KeyboardArrowDownOutlinedIcon />}
+                      onClick={(event) => handleNavItemClick(event, item)}
                     >
                       {item.title}
                     </UButton>
-                  </Link>
-                ) : (
-                  <UButton
-                    className={clsx('nav-item nav-button', {
-                      active: item.id === menuOpenNavItem?.id,
-                    })}
-                    id={`nav-button-${item.id}`}
-                    variant="text"
-                    key={item.id}
-                    endIcon={<KeyboardArrowDownOutlinedIcon />}
-                    onClick={(event) => handleNavItemClick(event, item)}
-                  >
-                    {item.title}
-                  </UButton>
-                )
-              )}
-              {navMenuOpen &&
-                menuOpenNavItem &&
-                menuOpenNavItem.type === 'list' && (
-                  <StyledNavMenu
-                    className="nav-menu"
-                    id="nav-item-menu"
-                    anchorEl={navItemAnchorEl}
-                    open={navMenuOpen}
-                    onClose={handleNavMenuClose}
-                    MenuListProps={{
-                      'aria-labelledby': 'nav-button',
-                    }}
-                    anchorOrigin={{
-                      vertical: 'bottom',
-                      horizontal: 'center',
-                    }}
-                    /**
-                     * 避免 menu 被 header 遮擋，做出 header 與 menu 重疊的效果
-                     * 但同時會導致 menu 的 overlay 不為 body 的 第一層 children
-                     * 因此需要將 body 固定
-                     */
-                    container={headerRef.current}
-                  >
-                    {menuOpenNavItem?.list.map((subItem) => (
-                      <MenuItem onClick={handleNavMenuClose} key={subItem.id}>
-                        {subItem.type === 'link' ? (
-                          <Link href={subItem.href}>
+                  )
+                )}
+                {navMenuOpen &&
+                  menuOpenNavItem &&
+                  menuOpenNavItem.type === 'list' && (
+                    <StyledNavMenu
+                      className="nav-menu"
+                      id="nav-item-menu"
+                      anchorEl={navItemAnchorEl}
+                      open={navMenuOpen}
+                      onClose={handleNavMenuClose}
+                      MenuListProps={{
+                        'aria-labelledby': 'nav-button',
+                      }}
+                      anchorOrigin={{
+                        vertical: 'bottom',
+                        horizontal: 'center',
+                      }}
+                      /**
+                       * 避免 menu 被 header 遮擋，做出 header 與 menu 重疊的效果
+                       * 但同時會導致 menu 的 overlay 不為 body 的 第一層 children
+                       * 因此需要將 body 固定
+                       */
+                      container={headerRef.current}
+                    >
+                      {menuOpenNavItem?.list.map((subItem) => (
+                        <MenuItem onClick={handleNavMenuClose} key={subItem.id}>
+                          {subItem.type === 'link' ? (
+                            <Link href={subItem.href}>
+                              <Typography fontWeight={700}>
+                                {subItem.title}
+                              </Typography>
+                            </Link>
+                          ) : (
                             <Typography fontWeight={700}>
                               {subItem.title}
                             </Typography>
-                          </Link>
-                        ) : (
-                          <Typography fontWeight={700}>
-                            {subItem.title}
-                          </Typography>
-                        )}
-                      </MenuItem>
-                    ))}
-                  </StyledNavMenu>
-                )}
-            </Box>
-            {/** 右側 */}
-            <Box display="flex" alignItems="center" gap={1}>
-              <UIconButton
-                className="nav-item icon-button"
-                variant="outlined"
-                color="default"
-                onClick={onProfileClick}
-                size="small"
-              >
-                <ProfileIcon width={14} />
-              </UIconButton>
-              <UIconButton
-                className="nav-item icon-button"
-                variant="outlined"
-                color="default"
-                onClick={handleSearchClick}
-                size="small"
-              >
-                <SearchIcon />
-              </UIconButton>
-              <Link href={ROUTES.HOME}>
-                <UButton
-                  className="donation-button"
-                  variant="contained"
-                  rounded
+                          )}
+                        </MenuItem>
+                      ))}
+                    </StyledNavMenu>
+                  )}
+              </Box>
+              {/** 右側 */}
+              <Box display="flex" alignItems="center" gap={1}>
+                <UIconButton
+                  className="nav-item icon-button"
+                  variant="outlined"
+                  color="default"
+                  onClick={onProfileClick}
+                  size="small"
                 >
-                  Donation
-                </UButton>
-              </Link>
-            </Box>
-          </>
-        )}
-      </StyledHeaderContainer>
-    </StyledHeader>
+                  <ProfileIcon width={14} />
+                </UIconButton>
+                <UIconButton
+                  className="nav-item icon-button"
+                  variant="outlined"
+                  color="default"
+                  onClick={handleSearchClick}
+                  size="small"
+                >
+                  <SearchIcon />
+                </UIconButton>
+                <Link href={ROUTES.HOME}>
+                  <UButton
+                    className="donation-button"
+                    variant="contained"
+                    rounded
+                  >
+                    Donation
+                  </UButton>
+                </Link>
+              </Box>
+            </>
+          )}
+        </StyledHeaderWrapper>
+      </StyledHeader>
+    </StyledHeaderContainer>
   )
 }
 

--- a/src/common/components/elements/Header/index.tsx
+++ b/src/common/components/elements/Header/index.tsx
@@ -30,8 +30,8 @@ const StyledHeaderContainer = styled(Container)(({ theme }) => ({
   top: theme.spacing(4.5),
   zIndex: theme.constants.zIndex.header,
   margin: `${theme.spacing(4.5)} auto`,
-  paddingLeft: `${theme.spacing(3)} !important`,
-  paddingRight: `${theme.spacing(3)} !important`,
+  paddingLeft: `${theme.spacing(0)} !important`,
+  paddingRight: `${theme.spacing(0)} !important`,
 }))
 
 const StyledHeader = styled('header')(({ theme }) => ({

--- a/src/common/components/elements/Header/index.tsx
+++ b/src/common/components/elements/Header/index.tsx
@@ -30,8 +30,6 @@ const StyledHeaderContainer = styled(Container)(({ theme }) => ({
   top: theme.spacing(4.5),
   zIndex: theme.constants.zIndex.header,
   margin: `${theme.spacing(4.5)} auto`,
-  paddingLeft: `${theme.spacing(0)} !important`,
-  paddingRight: `${theme.spacing(0)} !important`,
 }))
 
 const StyledHeader = styled('header')(({ theme }) => ({
@@ -181,7 +179,7 @@ const Header = ({ className, onProfileClick, onSearchClick }: HeaderProps) => {
   }
 
   return (
-    <StyledHeaderContainer maxWidth="lg">
+    <StyledHeaderContainer maxWidth="xl">
       <StyledHeader ref={headerRef} onClick={handleNavMenuClose}>
         <StyledHeaderWrapper
           className={className}

--- a/src/common/components/elements/IndexKvCards/index.tsx
+++ b/src/common/components/elements/IndexKvCards/index.tsx
@@ -3,22 +3,13 @@
 import UFullWidthBackgroundBox from '@/common/components/atoms/UFullWidthBackgroundBox'
 import Carousel from '@/common/components/elements/Carousel'
 import IndexKvCard from '@/common/components/elements/IndexKvCard'
-import { USTWTheme } from '@/common/lib/mui/theme'
 import { ROUTES } from '@/routes'
-import { Container, useTheme } from '@mui/material'
+import { Container } from '@mui/material'
 
 const IndexKVCards = () => {
-  const theme = useTheme<USTWTheme>()
-
   return (
     <UFullWidthBackgroundBox>
-      <Container
-        maxWidth="lg"
-        sx={{
-          paddingLeft: `${theme.spacing(0)} !important`,
-          paddingRight: `${theme.spacing(0)} !important`,
-        }}
-      >
+      <Container maxWidth="xl">
         <Carousel>
           <IndexKvCard
             tags={Array.from({ length: 100 }, (_, i) => `#${i + 1}`)}

--- a/src/common/components/elements/IndexKvCards/index.tsx
+++ b/src/common/components/elements/IndexKvCards/index.tsx
@@ -15,13 +15,12 @@ const IndexKVCards = () => {
       <Container
         maxWidth="lg"
         sx={{
-          paddingLeft: `${theme.spacing(2)} !important`,
-          paddingRight: `${theme.spacing(2)} !important`,
+          paddingLeft: `${theme.spacing(0)} !important`,
+          paddingRight: `${theme.spacing(0)} !important`,
         }}
       >
         <Carousel>
           <IndexKvCard
-            containerSx={{ margin: theme.spacing(0, 1) }}
             tags={Array.from({ length: 100 }, (_, i) => `#${i + 1}`)}
             title="快訊：美國政府宣布提供台灣 8000 萬美元外國軍事融資"
             description="美國時間8/30日，美聯社報導美國政府已正式通知國會，將向台灣提供8000萬美元「無償軍事援助」。去年底通過的2023財政年度國防授權法案（NDAA FY2023）中有一項「台灣增強韌性法案」（Taiwan Enhanced Resilience Act），授權美國國務院從2023年至2027年期間，每年提供台灣高達20億美元的軍援...美國時間8/30日，美聯社報導美國政府已正式通知國會，將向台灣提供8000萬美元「無償軍事援助」。去年底通過的2023財政年度國防授權法案（NDAA FY2023）中有一項「台灣增強韌性法案」（Taiwan Enhanced Resilience Act），授權美國國務院從2023年至2027年期間，每年提供台灣高達20億美元的軍援..."
@@ -29,7 +28,6 @@ const IndexKVCards = () => {
             href={ROUTES.BILL}
           />
           <IndexKvCard
-            containerSx={{ margin: theme.spacing(0, 1) }}
             tags={['#1', '#2', '#3']}
             title="快訊：美國政府宣布提供台灣 8000 萬美元外國軍事融資"
             description="美國時間8/30日，美聯社報導美國政府已正式通知國會，將向台灣提供8000萬美元「無償軍事援助」。去年底通過的2023財政年度國防授權法案（NDAA FY2023）中有一項「台灣增強韌性法案」（Taiwan Enhanced Resilience Act），授權美國國務院從2023年至2027年期間，每年提供台灣高達20億美元的軍援...美國時間8/30日，美聯社報導美國政府已正式通知國會，將向台灣提供8000萬美元「無償軍事援助」。去年底通過的2023財政年度國防授權法案（NDAA FY2023）中有一項「台灣增強韌性法案」（Taiwan Enhanced Resilience Act），授權美國國務院從2023年至2027年期間，每年提供台灣高達20億美元的軍援..."
@@ -37,7 +35,6 @@ const IndexKVCards = () => {
             href={ROUTES.BILL}
           />
           <IndexKvCard
-            containerSx={{ margin: theme.spacing(0, 1) }}
             tags={['#1', '#2', '#3']}
             title="快訊：美國政府宣布提供台灣 8000 萬美元外國軍事融資"
             description="美國時間8/30日，美聯社報導美國政府已正式通知國會，將向台灣提供8000萬美元「無償軍事援助」。去年底通過的2023財政年度國防授權法案（NDAA FY2023）中有一項「台灣增強韌性法案」（Taiwan Enhanced Resilience Act），授權美國國務院從2023年至2027年期間，每年提供台灣高達20億美元的軍援...美國時間8/30日，美聯社報導美國政府已正式通知國會，將向台灣提供8000萬美元「無償軍事援助」。去年底通過的2023財政年度國防授權法案（NDAA FY2023）中有一項「台灣增強韌性法案」（Taiwan Enhanced Resilience Act），授權美國國務院從2023年至2027年期間，每年提供台灣高達20億美元的軍援..."

--- a/src/common/components/elements/IndexKvCards/index.tsx
+++ b/src/common/components/elements/IndexKvCards/index.tsx
@@ -12,7 +12,13 @@ const IndexKVCards = () => {
 
   return (
     <UFullWidthBackgroundBox>
-      <Container>
+      <Container
+        maxWidth="lg"
+        sx={{
+          paddingLeft: `${theme.spacing(2)} !important`,
+          paddingRight: `${theme.spacing(2)} !important`,
+        }}
+      >
         <Carousel>
           <IndexKvCard
             containerSx={{ margin: theme.spacing(0, 1) }}

--- a/src/common/components/elements/Landing/LandingSectionWrapper.tsx
+++ b/src/common/components/elements/Landing/LandingSectionWrapper.tsx
@@ -10,11 +10,17 @@ type Props = {
   backgroundColor?: string
   children: ReactNode
   contentWrapperSx?: StackProps['sx']
+  /**
+   * 是否與 Header 同寬
+   * @default false
+   */
+  isHeaderWidth?: boolean
 }
 
 const LandingSectionWrapper = ({
   backgroundColor,
   contentWrapperSx,
+  isHeaderWidth = false,
   children,
 }: Props) => {
   const theme = useTheme<USTWTheme>()
@@ -26,7 +32,15 @@ const LandingSectionWrapper = ({
         borderRadius: '30px 30px 0 0',
       }}
     >
-      <Container>
+      <Container
+        maxWidth="lg"
+        sx={{
+          ...(isHeaderWidth && {
+            paddingLeft: `${theme.spacing(3)} !important`,
+            paddingRight: `${theme.spacing(3)} !important`,
+          }),
+        }}
+      >
         <Stack
           sx={{
             padding: '80px 0',

--- a/src/common/components/elements/Landing/LandingSectionWrapper.tsx
+++ b/src/common/components/elements/Landing/LandingSectionWrapper.tsx
@@ -32,15 +32,7 @@ const LandingSectionWrapper = ({
         borderRadius: '30px 30px 0 0',
       }}
     >
-      <Container
-        maxWidth="lg"
-        sx={{
-          ...(isHeaderWidth && {
-            paddingLeft: `${theme.spacing(0)} !important`,
-            paddingRight: `${theme.spacing(0)} !important`,
-          }),
-        }}
-      >
+      <Container maxWidth={isHeaderWidth ? 'xl' : 'lg'}>
         <Stack
           sx={{
             padding: '80px 0',

--- a/src/common/components/elements/Landing/LandingSectionWrapper.tsx
+++ b/src/common/components/elements/Landing/LandingSectionWrapper.tsx
@@ -36,8 +36,8 @@ const LandingSectionWrapper = ({
         maxWidth="lg"
         sx={{
           ...(isHeaderWidth && {
-            paddingLeft: `${theme.spacing(3)} !important`,
-            paddingRight: `${theme.spacing(3)} !important`,
+            paddingLeft: `${theme.spacing(0)} !important`,
+            paddingRight: `${theme.spacing(0)} !important`,
           }),
         }}
       >

--- a/src/common/lib/mui/theme.ts
+++ b/src/common/lib/mui/theme.ts
@@ -13,7 +13,12 @@ import {
   Noto_Sans_TC as NotoSansTC,
 } from 'next/font/google'
 import { Language } from '@/common/lib/i18n/types'
-import { colors, type Components, CreateMUIStyled } from '@mui/material'
+import {
+  BreakpointsOptions,
+  colors,
+  type Components,
+  CreateMUIStyled,
+} from '@mui/material'
 import { CSSProperties } from 'react'
 
 declare module '@mui/material/styles' {
@@ -331,32 +336,17 @@ const ketagalanPalette: PaletteOptions = {
   },
 }
 
-const commonThemeComponents: Components<Omit<Theme, 'components'>> = {
-  MuiContainer: {
-    styleOverrides: {
-      root: {
-        '&.MuiContainer-maxWidthLg': {
-          maxWidth: '1340px',
-        },
-        '@media (min-width:600px)': {
-          paddingLeft: '24px', // Padding for sm up
-          paddingRight: '24px', // Padding for sm up
-        },
-        '@media (min-width:900px)': {
-          paddingLeft: '32px', // Padding for md up
-          paddingRight: '32px', // Padding for md up
-        },
-        '@media (min-width:1200px)': {
-          paddingLeft: '40px', // Padding for lg up
-          paddingRight: '40px', // Padding for lg up
-        },
-        '@media (min-width:1536px)': {
-          paddingLeft: '50px', // Padding for xl up
-          paddingRight: '50px', // Padding for xl up
-        },
-      },
-    },
+const commonThemeBreakpoints: BreakpointsOptions = {
+  values: {
+    xs: 0,
+    sm: 600,
+    md: 900,
+    lg: 1288,
+    xl: 1388,
   },
+}
+
+const commonThemeComponents: Components<Omit<Theme, 'components'>> = {
   MuiButtonBase: {
     defaultProps: {
       disableRipple: true,
@@ -375,6 +365,7 @@ const commonThemeComponents: Components<Omit<Theme, 'components'>> = {
 }
 
 const _lightTheme: USTWThemeOptions = {
+  breakpoints: commonThemeBreakpoints,
   color: {
     ...color,
     header: {
@@ -417,6 +408,7 @@ const _lightTheme: USTWThemeOptions = {
 }
 
 const _ketagalanTheme: USTWThemeOptions = {
+  breakpoints: commonThemeBreakpoints,
   color: {
     ...color,
     header: {

--- a/src/common/lib/mui/theme.ts
+++ b/src/common/lib/mui/theme.ts
@@ -13,7 +13,7 @@ import {
   Noto_Sans_TC as NotoSansTC,
 } from 'next/font/google'
 import { Language } from '@/common/lib/i18n/types'
-import { colors, CreateMUIStyled } from '@mui/material'
+import { colors, type Components, CreateMUIStyled } from '@mui/material'
 import { CSSProperties } from 'react'
 
 declare module '@mui/material/styles' {
@@ -331,6 +331,34 @@ const ketagalanPalette: PaletteOptions = {
   },
 }
 
+const commonThemeComponents: Components<Omit<Theme, 'components'>> = {
+  MuiContainer: {
+    styleOverrides: {
+      root: {
+        '&.MuiContainer-maxWidthLg': {
+          maxWidth: '1340px',
+          padding: '0 50px',
+        },
+      },
+    },
+  },
+  MuiButtonBase: {
+    defaultProps: {
+      disableRipple: true,
+    },
+  },
+  MuiButton: {
+    styleOverrides: {
+      root: {
+        boxShadow: 'none',
+        '&:hover': {
+          boxShadow: 'none',
+        },
+      },
+    },
+  },
+}
+
 const _lightTheme: USTWThemeOptions = {
   color: {
     ...color,
@@ -369,21 +397,7 @@ const _lightTheme: USTWThemeOptions = {
     },
   },
   components: {
-    MuiButtonBase: {
-      defaultProps: {
-        disableRipple: true,
-      },
-    },
-    MuiButton: {
-      styleOverrides: {
-        root: {
-          boxShadow: 'none',
-          '&:hover': {
-            boxShadow: 'none',
-          },
-        },
-      },
-    },
+    ...commonThemeComponents,
   },
 }
 
@@ -425,21 +439,7 @@ const _ketagalanTheme: USTWThemeOptions = {
     },
   },
   components: {
-    MuiButtonBase: {
-      defaultProps: {
-        disableRipple: true,
-      },
-    },
-    MuiButton: {
-      styleOverrides: {
-        root: {
-          boxShadow: 'none',
-          '&:hover': {
-            boxShadow: 'none',
-          },
-        },
-      },
-    },
+    ...commonThemeComponents,
   },
 }
 

--- a/src/common/lib/mui/theme.ts
+++ b/src/common/lib/mui/theme.ts
@@ -337,7 +337,22 @@ const commonThemeComponents: Components<Omit<Theme, 'components'>> = {
       root: {
         '&.MuiContainer-maxWidthLg': {
           maxWidth: '1340px',
-          padding: '0 50px',
+        },
+        '@media (min-width:600px)': {
+          paddingLeft: '24px', // Padding for sm up
+          paddingRight: '24px', // Padding for sm up
+        },
+        '@media (min-width:900px)': {
+          paddingLeft: '32px', // Padding for md up
+          paddingRight: '32px', // Padding for md up
+        },
+        '@media (min-width:1200px)': {
+          paddingLeft: '40px', // Padding for lg up
+          paddingRight: '40px', // Padding for lg up
+        },
+        '@media (min-width:1536px)': {
+          paddingLeft: '74px', // Padding for xl up
+          paddingRight: '74px', // Padding for xl up
         },
       },
     },

--- a/src/common/lib/mui/theme.ts
+++ b/src/common/lib/mui/theme.ts
@@ -351,8 +351,8 @@ const commonThemeComponents: Components<Omit<Theme, 'components'>> = {
           paddingRight: '40px', // Padding for lg up
         },
         '@media (min-width:1536px)': {
-          paddingLeft: '74px', // Padding for xl up
-          paddingRight: '74px', // Padding for xl up
+          paddingLeft: '50px', // Padding for xl up
+          paddingRight: '50px', // Padding for xl up
         },
       },
     },

--- a/src/modules/Bill/components/IndexBillCard/IndexBillCardList.tsx
+++ b/src/modules/Bill/components/IndexBillCard/IndexBillCardList.tsx
@@ -27,7 +27,7 @@ export default function IndexBillCardList({
 }: IndexBillCardListProps) {
   return (
     <StyledUFullWidthBackgroundBox>
-      <Container>
+      <Container maxWidth="lg">
         <Carousel
           centerMode
           settings={{

--- a/src/modules/LandingPage/components/BillSection.tsx
+++ b/src/modules/LandingPage/components/BillSection.tsx
@@ -1,17 +1,20 @@
 'use client'
 
 import { BILL_DATA_MOCK } from '@/modules/Bill/data'
-import { Stack } from '@mui/material'
+import Container from '@mui/material/Container'
+import Stack from '@mui/material/Stack'
 import SectionTitleWithLink from '@/common/components/elements/Landing/SectionTitleWithLink'
 import IndexBillCardList from '@/modules/Bill/components/IndexBillCard/IndexBillCardList'
 import { ROUTES } from '@/routes'
 
 const BillSection = () => {
   return (
-    <Stack py={10} gap={7.5}>
-      <SectionTitleWithLink title="Bills" link={ROUTES.BILL} />
-      <IndexBillCardList billData={BILL_DATA_MOCK} />
-    </Stack>
+    <Container maxWidth="lg">
+      <Stack py={10} gap={7.5}>
+        <SectionTitleWithLink title="Bills" link={ROUTES.BILL} />
+        <IndexBillCardList billData={BILL_DATA_MOCK} />
+      </Stack>
+    </Container>
   )
 }
 

--- a/src/modules/LandingPage/components/FreeUsageSection.tsx
+++ b/src/modules/LandingPage/components/FreeUsageSection.tsx
@@ -16,7 +16,10 @@ const FreeUsageSection = () => {
   const theme = useTheme<USTWTheme>()
 
   return (
-    <LandingSectionWrapper backgroundColor={theme.color.lime[500]}>
+    <LandingSectionWrapper
+      backgroundColor={theme.color.lime[500]}
+      isHeaderWidth
+    >
       <Stack gap={4}>
         <Typography variant="h2" whiteSpace="pre-line">
           {'Stay Updated On The\nLatest '}

--- a/src/modules/Opinion/components/OpinionLanding/OpinionLandingBannerCard.tsx
+++ b/src/modules/Opinion/components/OpinionLanding/OpinionLandingBannerCard.tsx
@@ -13,9 +13,8 @@ import UHeightLimitedText from '@/common/components/atoms/UHeightLimitedText'
 import UTagList from '@/common/components/atoms/UTagList'
 import UWidthLimitedText from '@/common/components/atoms/UWidthLimitedText'
 
-const StyledOpinionLandingBannerCardContainer = styled(Box)(({ theme }) => ({
+const StyledOpinionLandingBannerCardContainer = styled(Box)(() => ({
   width: '100%',
-  padding: theme.spacing(2, 2, 2, 4),
   borderRadius: '30px',
 }))
 

--- a/src/modules/Opinion/components/OpinionLanding/OpinionPostSection.tsx
+++ b/src/modules/Opinion/components/OpinionLanding/OpinionPostSection.tsx
@@ -7,7 +7,8 @@ import { USTWTheme } from '@/common/lib/mui/theme'
 import useOpinionStore from '@/common/lib/zustand/hooks/useOpinionStore'
 import OpinionPostCards from '@/modules/Opinion/components/OpinionPostCards'
 import { opinions } from '@/modules/Opinion/data'
-import { Container, Stack, useTheme } from '@mui/material'
+import { useTheme } from '@mui/material'
+import Stack from '@mui/material/Stack'
 import { useEffect, useState } from 'react'
 
 const OpinionPostSection = () => {
@@ -31,25 +32,23 @@ const OpinionPostSection = () => {
         paddingBottom: theme.spacing(15),
       }}
     >
-      <Container maxWidth="lg">
-        <Stack spacing={8}>
-          {/** Tags */}
-          <UHStack gap={2} flexWrap="wrap">
-            {categories.map((category) => (
-              <UCategoryChip
-                key={category.id}
-                label={category.label}
-                img={category.image}
-                active={activeCategoryId === category.id}
-                onClick={() => setActiveCategoryId(category.id)}
-              />
-            ))}
-          </UHStack>
+      <Stack spacing={8}>
+        {/** Tags */}
+        <UHStack gap={2} flexWrap="wrap">
+          {categories.map((category) => (
+            <UCategoryChip
+              key={category.id}
+              label={category.label}
+              img={category.image}
+              active={activeCategoryId === category.id}
+              onClick={() => setActiveCategoryId(category.id)}
+            />
+          ))}
+        </UHStack>
 
-          {/** Posts */}
-          <OpinionPostCards opinions={opinions} />
-        </Stack>
-      </Container>
+        {/** Posts */}
+        <OpinionPostCards opinions={opinions} />
+      </Stack>
     </LandingSectionWrapper>
   )
 }

--- a/src/modules/Opinion/components/OpinionPost/OpinionFixed.tsx
+++ b/src/modules/Opinion/components/OpinionPost/OpinionFixed.tsx
@@ -3,13 +3,16 @@
 import UIconButton from '@/common/components/atoms/UIconButton'
 import { USTWTheme } from '@/common/lib/mui/theme'
 import { BookmarkIcon, OutlinedShareIcon } from '@/common/styles/assets/Icons'
-import { Box, Stack, useTheme } from '@mui/material'
+import { useTheme } from '@mui/material'
+import Container from '@mui/material/Container'
+import Stack from '@mui/material/Stack'
 
 const OpinionFixed = () => {
   const theme = useTheme<USTWTheme>()
 
   return (
-    <Box
+    <Container
+      maxWidth="lg"
       sx={{
         position: 'sticky',
         top: 300,
@@ -23,8 +26,7 @@ const OpinionFixed = () => {
         sx={{
           position: 'absolute',
           top: 0,
-          // hard code 因為要吃掉 container 的 padding，使他與 header 對齊
-          right: theme.spacing(-3),
+          right: theme.spacing(3),
           backgroundColor: 'white',
           borderRadius: '30px',
         }}
@@ -36,7 +38,7 @@ const OpinionFixed = () => {
           <OutlinedShareIcon />
         </UIconButton>
       </Stack>
-    </Box>
+    </Container>
   )
 }
 

--- a/src/modules/Opinion/components/OpinionPost/OpinionPostBanner.tsx
+++ b/src/modules/Opinion/components/OpinionPost/OpinionPostBanner.tsx
@@ -18,7 +18,7 @@ const OpinionPostBanner = function OpinionPostBanner({
       <ContentImage
         image={bannerImage.src}
         caption={bannerImage.caption}
-        sx={{ margin: 'auto', width: '1400px', maxWidth: '100%' }}
+        sx={{ margin: 'auto', width: '1000px', maxWidth: '100%' }}
       />
     </UFullWidthBackgroundBox>
   )

--- a/src/modules/Opinion/components/OpinionPost/OpinionPostHeader.tsx
+++ b/src/modules/Opinion/components/OpinionPost/OpinionPostHeader.tsx
@@ -41,7 +41,7 @@ const OpinionPostHeader = function OpinionPostHeader({
     <Stack spacing={3}>
       {/** Categories */}
       {categories && (
-        <UHStack gap={2}>
+        <UHStack gap={2} flexWrap="wrap">
           {categories.map((category, index) => (
             <UButton
               key={index}

--- a/src/modules/Opinion/components/OpinionPost/index.tsx
+++ b/src/modules/Opinion/components/OpinionPost/index.tsx
@@ -8,7 +8,9 @@ import OpinionPostDivider from '@/modules/Opinion/components/OpinionPost/Opinion
 import OpinionPostFooter from '@/modules/Opinion/components/OpinionPost/OpinionPostFooter'
 import OpinionPostHeader from '@/modules/Opinion/components/OpinionPost/OpinionPostHeader'
 import OpinionPostRelatedPosts from '@/modules/Opinion/components/OpinionPost/OpinionPostRelatedPosts'
-import { Container, Stack } from '@mui/material'
+import Box from '@mui/material/Box'
+import Container from '@mui/material/Container'
+import Stack from '@mui/material/Stack'
 import { Opinion, OpinionArgs } from '@/modules/Opinion/classes/Opinion'
 import OpinionFixed from '@/modules/Opinion/components/OpinionPost/OpinionFixed'
 
@@ -21,44 +23,58 @@ const OpinionPost = function OpinionPost({ opinionData }: OpinionPostProps) {
 
   return (
     <Stack gap={4} marginTop={10}>
-      <Stack gap={4}>
+      <Box>
         <OpinionFixed />
-        {/** Header Section */}
-        <OpinionPostHeader
-          categories={opinion.categories}
-          title={opinion.title}
-          subtitle={opinion.subtitle}
-          date={opinion.date}
-          tags={opinion.tags}
-          repostSources={opinion.repostSources}
-        />
-        {/** Banner Section */}
-        {opinion.bannerImage && (
-          <OpinionPostBanner bannerImage={opinion.bannerImage} />
-        )}
+        <Container maxWidth="lg">
+          <Box
+            sx={{
+              maxWidth: '700px',
+              margin: '0 auto',
+            }}
+          >
+            <Stack gap={4}>
+              {/** Header Section */}
+              <OpinionPostHeader
+                categories={opinion.categories}
+                title={opinion.title}
+                subtitle={opinion.subtitle}
+                date={opinion.date}
+                tags={opinion.tags}
+                repostSources={opinion.repostSources}
+              />
+              {/** Banner Section */}
+              {opinion.bannerImage && (
+                <OpinionPostBanner bannerImage={opinion.bannerImage} />
+              )}
 
-        {/** Content Section */}
-        {opinion.contentHtml && (
-          <OpinionPostContent contentHtml={opinion.contentHtml} />
-        )}
+              {/** Content Section */}
+              {opinion.contentHtml && (
+                <OpinionPostContent contentHtml={opinion.contentHtml} />
+              )}
 
-        {/** Footer Section */}
-        <OpinionPostDivider />
-        <OpinionPostFooter tags={opinion.tags} resources={opinion.resources} />
+              {/** Footer Section */}
+              <OpinionPostDivider />
+              <OpinionPostFooter
+                tags={opinion.tags}
+                resources={opinion.resources}
+              />
 
-        {/** Author Section */}
-        <OpinionPostDivider />
-        {opinion.author && (
-          <>
-            <OpinionPostAuthor author={opinion.author} />
-            <OpinionPostDivider />
-          </>
-        )}
-      </Stack>
+              {/** Author Section */}
+              <OpinionPostDivider />
+              {opinion.author && (
+                <>
+                  <OpinionPostAuthor author={opinion.author} />
+                  <OpinionPostDivider />
+                </>
+              )}
+            </Stack>
+          </Box>
+        </Container>
+      </Box>
 
       {/** Related Posts Section */}
       <UFullWidthBackgroundBox>
-        <Container maxWidth="xl">
+        <Container maxWidth="lg">
           <OpinionPostRelatedPosts />
         </Container>
       </UFullWidthBackgroundBox>

--- a/src/modules/People/components/PeopleLanding/PeopleListSection.tsx
+++ b/src/modules/People/components/PeopleLanding/PeopleListSection.tsx
@@ -1,6 +1,8 @@
 'use client'
 
-import { Box, Container, Grid2 as Grid, Stack } from '@mui/material'
+import Box from '@mui/material/Box'
+import Grid from '@mui/material/Grid2'
+import Stack from '@mui/material/Stack'
 import { useTheme } from '@mui/material/styles'
 import { USTWTheme } from '@/common/lib/mui/theme'
 import LandingSectionWrapper from '@/common/components/elements/Landing/LandingSectionWrapper'
@@ -20,34 +22,32 @@ const PeopleListSection = () => {
         paddingBottom: theme.spacing(15),
       }}
     >
-      <Container maxWidth="lg">
-        <Stack spacing={6} alignItems="center" justifyContent="center">
-          {/** People Filter */}
-          <PeopleFilter
-            onSubmit={(filter) => {
-              /** 這邊呼叫 API */
-              console.log(`call API with \n`, JSON.stringify(filter, null, 2))
-            }}
-          />
-          <Box>
-            <Grid container spacing={2}>
-              <Grid size={6}>
-                <PeopleCard people={people} simplified />
-              </Grid>
-              <Grid size={6}>
-                <PeopleCard people={people} simplified />
-              </Grid>
-              <Grid size={6}>
-                <PeopleCard people={people} simplified />
-              </Grid>
-              <Grid size={6}>
-                <PeopleCard people={people} simplified />
-              </Grid>
+      <Stack spacing={6} alignItems="center" justifyContent="center">
+        {/** People Filter */}
+        <PeopleFilter
+          onSubmit={(filter) => {
+            /** 這邊呼叫 API */
+            console.log(`call API with \n`, JSON.stringify(filter, null, 2))
+          }}
+        />
+        <Box>
+          <Grid container spacing={2}>
+            <Grid size={6}>
+              <PeopleCard people={people} simplified />
             </Grid>
-          </Box>
-          <UPagination count={10} page={1} onChange={() => {}} />
-        </Stack>
-      </Container>
+            <Grid size={6}>
+              <PeopleCard people={people} simplified />
+            </Grid>
+            <Grid size={6}>
+              <PeopleCard people={people} simplified />
+            </Grid>
+            <Grid size={6}>
+              <PeopleCard people={people} simplified />
+            </Grid>
+          </Grid>
+        </Box>
+        <UPagination count={10} page={1} onChange={() => {}} />
+      </Stack>
     </LandingSectionWrapper>
   )
 }

--- a/src/modules/Podcast/components/IndexPodcastCards.tsx
+++ b/src/modules/Podcast/components/IndexPodcastCards.tsx
@@ -24,7 +24,7 @@ const StyledUFullWidthBackgroundBox = styled(UFullWidthBackgroundBox)(() => ({
 const IndexPodcastCards = () => {
   return (
     <StyledUFullWidthBackgroundBox>
-      <Container>
+      <Container maxWidth="lg">
         <Carousel
           centerMode
           settings={{


### PR DESCRIPTION
## Summary

- 意外發現 Container width 跟設計對不上，順便整理了一下
  - 目前設計只有一種寬度: Header 寬: 1340px, Container 寬: 1240px
  - 有些區塊與 Header 同寬，因此 root layout 移除 `Container`，其他地方看設計稿而使用 `Container`
- Opinion post 文章頁的寬度 700px
- 意外發現 `import <Component> from "@mui/material/<Component>"` instead of `import {<Component>} from "@mui/material"`  在我電腦會改善 TypeScript autocompletion 太慢問題 

## Test Plan
首頁

https://github.com/user-attachments/assets/d061cc46-e116-43d3-95e4-13d66e4b819f


Bill

https://github.com/user-attachments/assets/1f4de661-966a-4523-aacf-eec84d7d2532

People


https://github.com/user-attachments/assets/6491e432-66e2-48a9-86ab-8d39cd37556d

Opinion


https://github.com/user-attachments/assets/a8f9d758-61f0-46af-9a07-b4d0c246f0bb





## Task
