### PR TITLE
fix: KT article link in footer

### DIFF
--- a/src/common/components/elements/Footer/useLinks.tsx
+++ b/src/common/components/elements/Footer/useLinks.tsx
@@ -104,7 +104,7 @@ export default function useLinks() {
         {
           type: 'subLink',
           title: 'Articles',
-          url: ROUTES.OPINION,
+          url: ROUTES.HOME,
         },
         {
           type: 'subLink',


### PR DESCRIPTION
## Summary

footer Ketagalan Media 區塊底下的 Articles 錯置成 Opinion 的 link，應為 KT media 的文章頁面，但非 phase1 scope，故先改為 home page

## Test Plan

https://github.com/user-attachments/assets/b27106ea-8782-4ad9-bd20-f6d81d7c21b2

## Task

https://dev.azure.com/ustw/US%20Taiwan%20Watch/_workitems/edit/155