### PR TITLE
feat: Article 超連結

### DIFF
--- a/src/modules/Opinion/components/OpinionPost/Content/HyperLinkTooltip.tsx
+++ b/src/modules/Opinion/components/OpinionPost/Content/HyperLinkTooltip.tsx
@@ -1,8 +1,9 @@
 'use client'
 
 import PeopleTooltip from '@/common/components/elements/HyperLinkTooltip/PeopleTooltip'
-import { styled, USTWTheme } from '@/common/lib/mui/theme'
-import { Tooltip, tooltipClasses, TooltipProps, useTheme } from '@mui/material'
+import { styled } from '@/common/lib/mui/theme'
+import { Tooltip, tooltipClasses, TooltipProps } from '@mui/material'
+import Link from 'next/link'
 
 const StyledTooltip = styled(({ className, ...props }: TooltipProps) => (
   <Tooltip {...props} classes={{ popper: className }} />
@@ -14,28 +15,27 @@ const StyledTooltip = styled(({ className, ...props }: TooltipProps) => (
 }))
 
 interface HyperLinkTooltipProps {
-  text: string
+  anchorEl: HTMLLinkElement
 }
 
 const HyperLinkTooltip = function HyperLinkTooltip({
-  text,
+  anchorEl,
 }: HyperLinkTooltipProps) {
-  const theme = useTheme<USTWTheme>()
-
   return (
     <StyledTooltip title={<PeopleTooltip />}>
-      <a
+      {/** 偽造一個連結元素，長寬尺寸都與 hover 的內部連結元素相同，並設定 hover 的內部連結元素的 tooltip */}
+      <Link
+        href={anchorEl.href}
         style={{
-          color: theme.color.orange[900],
-          fontSize: theme.typography.body.fontSize,
-          fontWeight: 400,
-          width: 'fit-content',
+          position: 'absolute',
+          top: anchorEl.offsetTop,
+          left: anchorEl.offsetLeft,
+          transform: 'translate(0%, -100%)',
+          width: anchorEl.offsetWidth,
+          height: anchorEl.offsetHeight,
+          cursor: 'pointer',
         }}
-        href="#"
-        target="_blank"
-      >
-        {text}
-      </a>
+      />
     </StyledTooltip>
   )
 }

--- a/src/modules/Opinion/components/OpinionPost/OpinionPostContent.tsx
+++ b/src/modules/Opinion/components/OpinionPost/OpinionPostContent.tsx
@@ -2,9 +2,9 @@
 
 import DOMPurify from 'dompurify'
 import { styled } from '@/common/lib/mui/theme'
-import ContentImage from '@/modules/Opinion/components/OpinionPost/Content/ContentImage'
 import HyperLinkTooltip from '@/modules/Opinion/components/OpinionPost/Content/HyperLinkTooltip'
 import { Stack } from '@mui/material'
+import { useState, useEffect } from 'react'
 
 const StyledContent = styled(Stack)(({ theme }) => ({
   '& h1': {
@@ -48,6 +48,12 @@ const StyledContent = styled(Stack)(({ theme }) => ({
       transform: 'translateY(-50%)',
     },
   },
+  '& [data-link-type="internal"]': {
+    color: theme.color.orange[900],
+    fontSize: theme.typography.body.fontSize,
+    fontWeight: 400,
+    width: 'fit-content',
+  },
   fontSize: theme.typography.body.fontSize,
   fontWeight: 400,
 }))
@@ -59,6 +65,43 @@ interface OpinionPostContentProps {
 const OpinionPostContent = function OpinionPostContent({
   contentHtml,
 }: OpinionPostContentProps) {
+  const [hoveredInternalLinkElem, setHoveredInternalLinkElem] =
+    useState<HTMLLinkElement | null>(null)
+
+  /**
+   * 在滑鼠進入內部連結時，設定 hover 的內部連結元素
+   */
+  const handleInternalLinkHover = (e: Event) => {
+    setHoveredInternalLinkElem(e.target as HTMLLinkElement)
+  }
+
+  /**
+   * 在滑鼠離開內部連結時，清除 hover 的內部連結元素
+   */
+  const handleInternalLinkLeave = () => {
+    setHoveredInternalLinkElem(null)
+  }
+
+  /**
+   * 監聽內部連結的 hover 事件
+   */
+  useEffect(() => {
+    const internalLinkElems = document.querySelectorAll(
+      '[data-link-type="internal"]'
+    )
+    internalLinkElems.forEach((elem) => {
+      console.log(elem)
+      elem.addEventListener('mouseenter', handleInternalLinkHover)
+      elem.addEventListener('mouseleave', handleInternalLinkLeave)
+    })
+    return () => {
+      internalLinkElems.forEach((elem) => {
+        elem.removeEventListener('mouseenter', handleInternalLinkHover)
+        elem.removeEventListener('mouseleave', handleInternalLinkLeave)
+      })
+    }
+  }, [hoveredInternalLinkElem])
+
   return (
     <Stack spacing={2}>
       <StyledContent
@@ -67,13 +110,10 @@ const OpinionPostContent = function OpinionPostContent({
           __html: DOMPurify.sanitize(contentHtml),
         }}
       />
-      <HyperLinkTooltip text="超連結" />
-      <ContentImage
-        image={'/assets/category1.jpg'}
-        caption={
-          '1967年，中國共產黨主席毛澤東掀起文化大革命，當時在北京市中心展示了他的巨大畫像與標語。（攝影／JEAN VINCENT／AFP）'
-        }
-      />
+      {/** 顯示 hover 的內部連結元素的 tooltip */}
+      {hoveredInternalLinkElem && (
+        <HyperLinkTooltip anchorEl={hoveredInternalLinkElem} />
+      )}
     </Stack>
   )
 }


### PR DESCRIPTION
## Summary

> 只考慮 PC 用戶

根據使用者滑鼠進入被預埋的超連結後，偽造一個元素在一樣的位置及尺寸，進而觸發 MUI 的 Tooltip

怎辦感覺超不 robust 求救

## Test Plan


https://github.com/user-attachments/assets/017e04d6-2697-4a25-96f0-9cc89a16a8f0



## Task

https://dev.azure.com/ustw/US%20Taiwan%20Watch/_backlogs/backlog/Try%20Tech/Requirements?workitem=177