### PR TITLE
feat: 調整 Opinion tag 與 category

### DIFF
--- a/src/app/[lang]/opinion/page.tsx
+++ b/src/app/[lang]/opinion/page.tsx
@@ -5,10 +5,7 @@ import { Language } from '@/common/lib/i18n/types'
 import OpinionLandingBannerCards from '@/modules/Opinion/components/OpinionLanding/OpinionLandingBannerCards'
 import OpinionPostSection from '@/modules/Opinion/components/OpinionLanding/OpinionPostSection'
 import OpinionNavbar from '@/modules/Opinion/components/OpinionNavbar'
-import {
-  findAllOpinion,
-  findLandingBannerOpinions,
-} from '@/modules/Opinion/data'
+import { findLandingBannerOpinions } from '@/modules/Opinion/data'
 import { Opinion as OpinionClass } from '@/modules/Opinion/classes/Opinion'
 import Container from '@mui/material/Container'
 import Stack from '@mui/material/Stack'
@@ -20,8 +17,6 @@ interface OpinionPageProps {
 }
 
 export default function Opinion({ params }: OpinionPageProps) {
-  const dtos = findAllOpinion()
-  const opinions = dtos.map((dto) => OpinionClass.fromDTO(params.lang, dto))
   const landingBannerDtos = findLandingBannerOpinions()
   const landingBannerOpinions = landingBannerDtos.map((dto) =>
     OpinionClass.fromDTO(params.lang, dto)
@@ -34,7 +29,7 @@ export default function Opinion({ params }: OpinionPageProps) {
           <OpinionNavbar />
         </UFullWidthBackgroundBox>
         <OpinionLandingBannerCards opinions={landingBannerOpinions} />
-        <OpinionPostSection opinions={opinions} />
+        <OpinionPostSection />
       </Stack>
     </Container>
   )

--- a/src/common/lib/zustand/hooks/useOpinionStore.ts
+++ b/src/common/lib/zustand/hooks/useOpinionStore.ts
@@ -1,29 +1,29 @@
+import { Tag } from '@/common/lib/graphql/__generated__/graphql'
 import { config } from '@/config'
 import OpinionCategory from '@/modules/Opinion/classes/OpinionCategory'
 import { mountStoreDevtool } from 'simple-zustand-devtools'
 import { create } from 'zustand'
 
 type State = {
-  /** 首頁分類 */
-  homeCategories: Array<OpinionCategory>
+  /** 首頁 Tags */
+  landingTags: Array<Tag>
   /** 熱門分類，存在在 NavBar 中 */
   highlightedCategories: Array<OpinionCategory>
 }
 
 type Action = {
-  setHomeCategories: (categories: Array<OpinionCategory>) => void
+  setLandingTags: (tags: Array<Tag>) => void
   setHomeHighlightedCategories: (categories: Array<OpinionCategory>) => void
 }
 
 const initialState: State = {
-  homeCategories: [],
+  landingTags: [],
   highlightedCategories: [],
 }
 
 const useOpinionStore = create<State & Action>((set) => ({
   ...initialState,
-  setHomeCategories: (categories) =>
-    set(() => ({ homeCategories: categories })),
+  setLandingTags: (tags) => set(() => ({ landingTags: tags })),
   setHomeHighlightedCategories: (categories) =>
     set(() => ({ highlightedCategories: categories })),
 }))

--- a/src/modules/Bill/classes/Bill.ts
+++ b/src/modules/Bill/classes/Bill.ts
@@ -235,7 +235,7 @@ export class Bill {
             cosponsor.people ? People.fromDTO(lang, cosponsor.people) : null
           )
           .filter((cosponsor) => !isNull(cosponsor)) ?? [],
-      tags: TagUtils.parseTags(lang, dto.tags),
+      tags: TagUtils.parseTagNames(lang, dto.tags),
       statusTracker: dto.statusTracker ?? undefined,
       congressNumber: dto.congress,
       // TODO: 型態待補

--- a/src/modules/Bill/components/BillLanding/PopularTags.tsx
+++ b/src/modules/Bill/components/BillLanding/PopularTags.tsx
@@ -18,7 +18,7 @@ export default function PopularTags() {
     <Stack px={2} spacing={2}>
       <Typography variant="subtitleS">Popular Tags :</Typography>
       <UHStack spacing={1}>
-        {TagUtils.parseTags(
+        {TagUtils.parseTagNames(
           lang,
           topTags.map(({ tag }) => tag)
         ).map((tag, index) => (

--- a/src/modules/Common/Tag.utils.ts
+++ b/src/modules/Common/Tag.utils.ts
@@ -4,18 +4,18 @@ import CommonUtils from '@/modules/Common/Common.utils'
 import { isString } from 'lodash-es'
 
 export default class TagUtils {
-  static parseTag(lang: Language, tag?: Maybe<Tag>) {
+  static parseTagName(lang: Language, tag?: Maybe<Tag>) {
     if (!tag) return undefined
     return tag.i18n?.[CommonUtils.parseAPII18nKey(lang)]?.name ?? undefined
   }
 
-  static parseTags(
+  static parseTagNames(
     lang: Language,
     tags?: Maybe<Maybe<Tag | undefined>[]>
   ): string[] {
     if (!tags) return []
     return tags
-      .map((tag) => TagUtils.parseTag(lang, tag))
+      .map((tag) => TagUtils.parseTagName(lang, tag))
       .filter((tag) => isString(tag))
   }
 }

--- a/src/modules/Common/dtoData.ts
+++ b/src/modules/Common/dtoData.ts
@@ -1,0 +1,40 @@
+import { Tag } from '@/common/lib/graphql/__generated__/graphql'
+
+export const TAGS_DTO_MOCK = [
+  {
+    id: '6758e385e981ce40d9597c90',
+    isFeatured: true,
+    i18n: {
+      en: {
+        name: 'TSMC',
+      },
+      zh: {
+        name: '台積電',
+      },
+    },
+  },
+  {
+    id: '6758e2c4e981ce40d9597c5a',
+    isFeatured: true,
+    i18n: {
+      en: {
+        name: 'Shutsung Liao',
+      },
+      zh: {
+        name: '廖述宗',
+      },
+    },
+  },
+  {
+    id: '6749a45ca313f435f157fc3a',
+    isFeatured: true,
+    i18n: {
+      en: {
+        name: 'Taiwan Caucus',
+      },
+      zh: {
+        name: '國會台灣連線',
+      },
+    },
+  },
+] as unknown as Array<Tag>

--- a/src/modules/LandingPage/components/ArticleSection.tsx
+++ b/src/modules/LandingPage/components/ArticleSection.tsx
@@ -11,17 +11,21 @@ import { useEffect, useState } from 'react'
 import OpinionPostCards from '@/modules/Opinion/components/OpinionPostCards'
 import useOpinionIndex from '@/modules/Opinion/hooks/useOpinionIndex'
 import { ROUTES } from '@/routes'
+import CommonUtils from '@/modules/Common/Common.utils'
+import { useParams } from 'next/navigation'
+import { Language } from '@/common/lib/i18n/types'
 
 const ArticleSection = () => {
+  const { lang } = useParams<{ lang: Language }>()
   const [activeCategoryId, setActiveCategoryId] = useState<string | undefined>()
-  const homeCategories = useOpinionStore((state) => state.homeCategories)
+  const landingTags = useOpinionStore((state) => state.landingTags)
 
   // 預設塞第一個
   useEffect(() => {
-    if (homeCategories.length > 0) {
-      setActiveCategoryId(homeCategories[0].id)
+    if (landingTags.length > 0) {
+      setActiveCategoryId(landingTags[0]?.id ?? undefined)
     }
-  }, [homeCategories])
+  }, [landingTags])
 
   const { opinions } = useOpinionIndex(activeCategoryId)
 
@@ -34,13 +38,12 @@ const ArticleSection = () => {
       <SectionTitleWithLink title="Articles" link={ROUTES.OPINION} />
       <Stack gap={5}>
         <UHStack gap={2}>
-          {homeCategories.map((category) => (
+          {landingTags.map((tag) => (
             <UCategoryChip
-              key={category.id}
-              label={category.label}
-              img={category.image}
-              active={activeCategoryId === category.id}
-              onClick={() => setActiveCategoryId(category.id)}
+              key={tag.id}
+              label={tag.i18n?.[CommonUtils.parseAPII18nKey(lang)]?.name ?? ''}
+              active={activeCategoryId === tag.id}
+              onClick={() => setActiveCategoryId(tag.id ?? undefined)}
             />
           ))}
         </UHStack>

--- a/src/modules/Opinion/components/OpinionLanding/OpinionPostSection.tsx
+++ b/src/modules/Opinion/components/OpinionLanding/OpinionPostSection.tsx
@@ -3,30 +3,21 @@
 import UCategoryChip from '@/common/components/atoms/UCategoryChip'
 import UHStack from '@/common/components/atoms/UHStack'
 import LandingSectionWrapper from '@/common/components/elements/Landing/LandingSectionWrapper'
+import { Language } from '@/common/lib/i18n/types'
 import { USTWTheme } from '@/common/lib/mui/theme'
-import useOpinionStore from '@/common/lib/zustand/hooks/useOpinionStore'
-import { Opinion } from '@/modules/Opinion/classes/Opinion'
+import CommonUtils from '@/modules/Common/Common.utils'
 import OpinionPostCards from '@/modules/Opinion/components/OpinionPostCards'
+import useOpinionIndex from '@/modules/Opinion/hooks/useOpinionIndex'
 import { useTheme } from '@mui/material'
 import Stack from '@mui/material/Stack'
-import { useEffect, useState } from 'react'
+import { useParams } from 'next/navigation'
+import { useState } from 'react'
 
-interface OpinionPostSectionProps {
-  opinions: Opinion[]
-}
-
-const OpinionPostSection = ({ opinions }: OpinionPostSectionProps) => {
+const OpinionPostSection = () => {
+  const { lang } = useParams<{ lang: Language }>()
   const theme = useTheme<USTWTheme>()
-  const [activeCategoryId, setActiveCategoryId] = useState<string | undefined>()
-
-  const homeCategories = useOpinionStore((state) => state.homeCategories)
-
-  // 預設塞第一個
-  useEffect(() => {
-    if (homeCategories.length > 0) {
-      setActiveCategoryId(homeCategories[0].id)
-    }
-  }, [homeCategories])
+  const [activeTagId, setActiveTagId] = useState<string | undefined>()
+  const { opinions, landingTags } = useOpinionIndex(activeTagId)
 
   return (
     <LandingSectionWrapper
@@ -39,13 +30,18 @@ const OpinionPostSection = ({ opinions }: OpinionPostSectionProps) => {
       <Stack spacing={8}>
         {/** Tags */}
         <UHStack gap={2} flexWrap="wrap">
-          {homeCategories.map((category) => (
+          {landingTags.map((tag) => (
             <UCategoryChip
-              key={category.id}
-              label={category.label}
-              img={category.image}
-              active={activeCategoryId === category.id}
-              onClick={() => setActiveCategoryId(category.id)}
+              key={tag.id}
+              label={tag.i18n?.[CommonUtils.parseAPII18nKey(lang)]?.name ?? ''}
+              active={activeTagId === tag.id}
+              onClick={() => {
+                if (activeTagId === tag.id) {
+                  setActiveTagId(undefined)
+                } else {
+                  setActiveTagId(tag.id ?? undefined)
+                }
+              }}
             />
           ))}
         </UHStack>

--- a/src/modules/Opinion/components/OpinionLanding/OpinionPostSection.tsx
+++ b/src/modules/Opinion/components/OpinionLanding/OpinionPostSection.tsx
@@ -30,20 +30,26 @@ const OpinionPostSection = () => {
       <Stack spacing={8}>
         {/** Tags */}
         <UHStack gap={2} flexWrap="wrap">
-          {landingTags.map((tag) => (
-            <UCategoryChip
-              key={tag.id}
-              label={tag.i18n?.[CommonUtils.parseAPII18nKey(lang)]?.name ?? ''}
-              active={activeTagId === tag.id}
-              onClick={() => {
-                if (activeTagId === tag.id) {
-                  setActiveTagId(undefined)
-                } else {
-                  setActiveTagId(tag.id ?? undefined)
+          {landingTags.map((tag) => {
+            const isActive = activeTagId === tag.id
+
+            return (
+              <UCategoryChip
+                key={tag.id}
+                label={
+                  tag.i18n?.[CommonUtils.parseAPII18nKey(lang)]?.name ?? ''
                 }
-              }}
-            />
-          ))}
+                active={isActive}
+                onClick={() => {
+                  if (isActive) {
+                    setActiveTagId(undefined)
+                  } else {
+                    setActiveTagId(tag.id ?? undefined)
+                  }
+                }}
+              />
+            )
+          })}
         </UHStack>
 
         {/** Posts */}

--- a/src/modules/Opinion/data.ts
+++ b/src/modules/Opinion/data.ts
@@ -4,7 +4,10 @@ import {
 } from '@/common/lib/graphql/__generated__/graphql'
 import { Opinion } from '@/modules/Opinion/classes/Opinion'
 import { OpinionCategoryArgs } from '@/modules/Opinion/classes/OpinionCategory'
-import { OPINION_DTO_MOCK } from '@/modules/Opinion/dtoData'
+import {
+  CATEGORIES_DTO_MOCK,
+  OPINION_DTO_MOCK,
+} from '@/modules/Opinion/dtoData'
 
 export const OpinionResponse = {
   id: '1',
@@ -239,19 +242,7 @@ export const homeOpinionCategories: Array<OpinionCategoryArgs> = [
 ]
 
 export const getOpinionCategories = (): CategoriesArticle[] => {
-  return [
-    {
-      id: '67556e61b3045c861e2c7059',
-      i18n: {
-        en: {
-          name: 'U.S.-Taiwan Relations',
-        },
-        zh: {
-          name: '台美關係',
-        },
-      },
-    },
-  ]
+  return CATEGORIES_DTO_MOCK
 }
 
 export const findAllOpinion = () => {

--- a/src/modules/Opinion/dtoData.ts
+++ b/src/modules/Opinion/dtoData.ts
@@ -1,4 +1,7 @@
-import { Article } from '@/common/lib/graphql/__generated__/graphql'
+import {
+  Article,
+  CategoriesArticle,
+} from '@/common/lib/graphql/__generated__/graphql'
 
 export const OPINION_DTO_MOCK = [
   {
@@ -3357,3 +3360,61 @@ export const OPINION_DTO_MOCK = [
     createdAt: '2024-12-09T02:46:45.238Z',
   },
 ] as unknown as Article[]
+
+export const CATEGORIES_DTO_MOCK = [
+  {
+    id: '67651455bc0742133dc7db2e',
+    i18n: {
+      en: {
+        name: 'International Politics',
+      },
+      zh: {
+        name: '國際政治',
+      },
+    },
+  },
+  {
+    id: '67651449bc0742133dc7db26',
+    i18n: {
+      en: {
+        name: 'International Economy',
+      },
+      zh: {
+        name: '國際經濟',
+      },
+    },
+  },
+  {
+    id: '6765143ebc0742133dc7db1e',
+    i18n: {
+      en: {
+        name: 'International News',
+      },
+      zh: {
+        name: '國際新聞',
+      },
+    },
+  },
+  {
+    id: '67651431bc0742133dc7db16',
+    i18n: {
+      en: {
+        name: 'US Legislation',
+      },
+      zh: {
+        name: '美國法案',
+      },
+    },
+  },
+  {
+    id: '67556e61b3045c861e2c7059',
+    i18n: {
+      en: {
+        name: 'U.S.-Taiwan Relations',
+      },
+      zh: {
+        name: '台美關係',
+      },
+    },
+  },
+] as unknown as CategoriesArticle[]

--- a/src/modules/Opinion/hooks/useOpinionIndex.ts
+++ b/src/modules/Opinion/hooks/useOpinionIndex.ts
@@ -1,12 +1,15 @@
 /** 首頁的精選文章 */
 
+import { Language } from '@/common/lib/i18n/types'
 import useOpinionStore from '@/common/lib/zustand/hooks/useOpinionStore'
 import { Opinion } from '@/modules/Opinion/classes/Opinion'
-import { opinions as MOCK_OPINIONS } from '@/modules/Opinion/data'
+import { OPINION_DTO_MOCK } from '@/modules/Opinion/dtoData'
+import { useParams } from 'next/navigation'
 import { useEffect, useState } from 'react'
 
-export default function useOpinionIndex(categoryId?: string) {
-  const homeCategories = useOpinionStore((state) => state.homeCategories)
+export default function useOpinionIndex(tagId?: string) {
+  const { lang } = useParams<{ lang: Language }>()
+  const landingTags = useOpinionStore((state) => state.landingTags)
 
   const [opinions, setOpinions] = useState<Array<Opinion>>([])
   const [isOpinionsLoading, setIsOpinionsLoading] = useState<boolean>(true)
@@ -14,12 +17,20 @@ export default function useOpinionIndex(categoryId?: string) {
   /** 每一次點選不同的 categoryId 時，都會重新取得資料 */
   useEffect(() => {
     // TODO: 從 API 取得資料
-    setOpinions(MOCK_OPINIONS.slice(0, 4))
+    if (tagId) {
+      setOpinions(
+        OPINION_DTO_MOCK.filter((opinion) =>
+          opinion.tags?.some((tag) => tag.id === tagId)
+        ).map((dto) => Opinion.fromDTO(lang, dto))
+      )
+    } else {
+      setOpinions(OPINION_DTO_MOCK.map((dto) => Opinion.fromDTO(lang, dto)))
+    }
     setIsOpinionsLoading(false)
-  }, [categoryId])
+  }, [lang, tagId])
 
   return {
-    homeCategories,
+    landingTags,
     opinions,
     isOpinionsLoading,
   }

--- a/src/modules/Opinion/hooks/useOpinionIndex.ts
+++ b/src/modules/Opinion/hooks/useOpinionIndex.ts
@@ -19,9 +19,10 @@ export default function useOpinionIndex(tagId?: string) {
     // TODO: 從 API 取得資料
     if (tagId) {
       setOpinions(
-        OPINION_DTO_MOCK.filter((opinion) =>
-          opinion.tags?.some((tag) => tag.id === tagId)
-        ).map((dto) => Opinion.fromDTO(lang, dto))
+        OPINION_DTO_MOCK.filter((opinion) => {
+          const tagSet = new Set(opinion.tags?.map((tag) => tag.id))
+          return tagSet.has(tagId)
+        }).map((dto) => Opinion.fromDTO(lang, dto))
       )
     } else {
       setOpinions(OPINION_DTO_MOCK.map((dto) => Opinion.fromDTO(lang, dto)))

--- a/src/modules/Opinion/hooks/useOpinionSearch.ts
+++ b/src/modules/Opinion/hooks/useOpinionSearch.ts
@@ -7,7 +7,9 @@ import { useEffect, useMemo, useState } from 'react'
 
 export default function useOpinionSearch(categoryId: string) {
   const { lang } = useParams<{ lang: Language }>()
-  const homeCategories = useOpinionStore((state) => state.homeCategories)
+  const highlightedCategories = useOpinionStore(
+    (state) => state.highlightedCategories
+  )
 
   const [opinions, setOpinions] = useState<Array<Opinion>>([])
   const [isOpinionsLoading, setIsOpinionsLoading] = useState<boolean>(true)
@@ -23,12 +25,12 @@ export default function useOpinionSearch(categoryId: string) {
   }, [categoryId, lang])
 
   const category = useMemo(
-    () => homeCategories.find((category) => category.id === categoryId),
-    [categoryId, homeCategories]
+    () => highlightedCategories.find((category) => category.id === categoryId),
+    [categoryId, highlightedCategories]
   )
 
   return {
-    homeCategories,
+    highlightedCategories,
     category,
     opinions,
     isOpinionsLoading,

--- a/src/modules/Opinion/providers/CategoryProvider.tsx
+++ b/src/modules/Opinion/providers/CategoryProvider.tsx
@@ -2,34 +2,28 @@
 
 import { Language } from '@/common/lib/i18n/types'
 import useOpinionStore from '@/common/lib/zustand/hooks/useOpinionStore'
+import { TAGS_DTO_MOCK } from '@/modules/Common/dtoData'
 import OpinionCategory from '@/modules/Opinion/classes/OpinionCategory'
-import {
-  getOpinionCategories,
-  highlightedOpinionCategories,
-} from '@/modules/Opinion/data'
+import { getOpinionCategories } from '@/modules/Opinion/data'
 import { useParams } from 'next/navigation'
 import { useEffect } from 'react'
 
 export default function CategoryProvider() {
   const { lang } = useParams<{ lang: Language }>()
 
-  const setHomeCategories = useOpinionStore((state) => state.setHomeCategories)
+  const setLandingTags = useOpinionStore((state) => state.setLandingTags)
   const setHomeHighlightedCategories = useOpinionStore(
     (state) => state.setHomeHighlightedCategories
   )
 
   useEffect(() => {
-    setHomeCategories(
+    setLandingTags(TAGS_DTO_MOCK.filter((tag) => tag.isFeatured))
+    setHomeHighlightedCategories(
       getOpinionCategories().map((category) =>
         OpinionCategory.fromDTO(lang, category)
       )
     )
-    setHomeHighlightedCategories(
-      highlightedOpinionCategories.map(
-        (category) => new OpinionCategory(category)
-      )
-    )
-  }, [setHomeCategories, setHomeHighlightedCategories, lang])
+  }, [setLandingTags, setHomeHighlightedCategories, lang])
 
   return null
 }

--- a/src/modules/People/classes/People.ts
+++ b/src/modules/People/classes/People.ts
@@ -292,7 +292,7 @@ export class People {
       congress: Congress.fromPeopleCongressDTO(dto.congressionalData),
       tags:
         dto.tags
-          ?.map((tag) => TagUtils.parseTag(lang, tag))
+          ?.map((tag) => TagUtils.parseTagName(lang, tag))
           .filter((name) => isString(name)) ?? [],
       partyExperience: People.parsePartyExperienceArgsFromDTO(
         dto.partyChangeRecords


### PR DESCRIPTION
## Summary

- 調整 Opinion tag 與 category
  - 上排category需用真實資料，點擊後功能尚待實作
  - opinion landing 下方為 tags 非 categories

## Test Plan

![CleanShot 2024-12-20 at 17 14 13@2x](https://github.com/user-attachments/assets/9cbf3a66-ff39-4ef6-8782-ddeae8248d8b)

https://github.com/user-attachments/assets/34cf7d0e-6d5c-40ed-842d-0df77da7f163



## Task
https://dev.azure.com/ustw/US%20Taiwan%20Watch/_backlogs/backlog/Try%20Tech/Requirements?workitem=177