### PR TITLE
feat: Landing opinion limit and sort

### DIFF
--- a/src/app/[lang]/opinion/layout.tsx
+++ b/src/app/[lang]/opinion/layout.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import CategoryProvider from '@/modules/Opinion/providers/CategoryProvider'
+import OpinionStoreProvider from '@/modules/Opinion/providers/OpinionStoreProvider'
 
 export default function OpinionLayout({
   children,
@@ -8,7 +8,7 @@ export default function OpinionLayout({
 }) {
   return (
     <>
-      <CategoryProvider />
+      <OpinionStoreProvider />
       {children}
     </>
   )

--- a/src/modules/LandingPage/components/ArticleSection.tsx
+++ b/src/modules/LandingPage/components/ArticleSection.tsx
@@ -7,51 +7,56 @@ import LandingSectionWrapper from '@/common/components/elements/Landing/LandingS
 import { SectionTitleWithLink } from '@/common/components/elements/Landing/SectionTitle'
 import { OVERLAPPED_SECTION_PADDING_BOTTOM } from '@/modules/LandingPage/constants'
 import useOpinionStore from '@/common/lib/zustand/hooks/useOpinionStore'
-import { useEffect, useState } from 'react'
+import { useState } from 'react'
 import OpinionPostCards from '@/modules/Opinion/components/OpinionPostCards'
 import useOpinionIndex from '@/modules/Opinion/hooks/useOpinionIndex'
 import { ROUTES } from '@/routes'
 import CommonUtils from '@/modules/Common/Common.utils'
 import { useParams } from 'next/navigation'
 import { Language } from '@/common/lib/i18n/types'
+import CategoryProvider from '@/modules/Opinion/providers/CategoryProvider'
 
 const ArticleSection = () => {
   const { lang } = useParams<{ lang: Language }>()
   const [activeCategoryId, setActiveCategoryId] = useState<string | undefined>()
   const landingTags = useOpinionStore((state) => state.landingTags)
 
-  // 預設塞第一個
-  useEffect(() => {
-    if (landingTags.length > 0) {
-      setActiveCategoryId(landingTags[0]?.id ?? undefined)
-    }
-  }, [landingTags])
-
-  const { opinions } = useOpinionIndex(activeCategoryId)
+  const { opinions } = useOpinionIndex(activeCategoryId, 3)
 
   return (
-    <LandingSectionWrapper
-      contentWrapperSx={{
-        paddingBottom: `${OVERLAPPED_SECTION_PADDING_BOTTOM}px`,
-      }}
-    >
-      <SectionTitleWithLink title="Articles" link={ROUTES.OPINION} />
-      <Stack gap={5}>
-        <UHStack gap={2}>
-          {landingTags.map((tag) => (
-            <UCategoryChip
-              key={tag.id}
-              label={tag.i18n?.[CommonUtils.parseAPII18nKey(lang)]?.name ?? ''}
-              active={activeCategoryId === tag.id}
-              onClick={() => setActiveCategoryId(tag.id ?? undefined)}
-            />
-          ))}
-        </UHStack>
+    <>
+      <CategoryProvider />
+      <LandingSectionWrapper
+        contentWrapperSx={{
+          paddingBottom: `${OVERLAPPED_SECTION_PADDING_BOTTOM}px`,
+        }}
+      >
+        <SectionTitleWithLink title="Articles" link={ROUTES.OPINION} />
+        <Stack gap={5}>
+          <UHStack gap={2}>
+            {landingTags.map((tag) => (
+              <UCategoryChip
+                key={tag.id}
+                label={
+                  tag.i18n?.[CommonUtils.parseAPII18nKey(lang)]?.name ?? ''
+                }
+                active={activeCategoryId === tag.id}
+                onClick={() => {
+                  if (activeCategoryId === tag.id) {
+                    setActiveCategoryId(undefined)
+                  } else {
+                    setActiveCategoryId(tag.id ?? undefined)
+                  }
+                }}
+              />
+            ))}
+          </UHStack>
 
-        {/** Posts */}
-        <OpinionPostCards opinions={opinions} pagination={false} />
-      </Stack>
-    </LandingSectionWrapper>
+          {/** Posts */}
+          <OpinionPostCards opinions={opinions} pagination={false} />
+        </Stack>
+      </LandingSectionWrapper>
+    </>
   )
 }
 

--- a/src/modules/LandingPage/components/ArticleSection.tsx
+++ b/src/modules/LandingPage/components/ArticleSection.tsx
@@ -14,7 +14,7 @@ import { ROUTES } from '@/routes'
 import CommonUtils from '@/modules/Common/Common.utils'
 import { useParams } from 'next/navigation'
 import { Language } from '@/common/lib/i18n/types'
-import CategoryProvider from '@/modules/Opinion/providers/CategoryProvider'
+import OpinionStoreProvider from '@/modules/Opinion/providers/OpinionStoreProvider'
 
 const ArticleSection = () => {
   const { lang } = useParams<{ lang: Language }>()
@@ -25,7 +25,7 @@ const ArticleSection = () => {
 
   return (
     <>
-      <CategoryProvider />
+      <OpinionStoreProvider />
       <LandingSectionWrapper
         contentWrapperSx={{
           paddingBottom: `${OVERLAPPED_SECTION_PADDING_BOTTOM}px`,

--- a/src/modules/Opinion/hooks/useOpinionIndex.ts
+++ b/src/modules/Opinion/hooks/useOpinionIndex.ts
@@ -7,7 +7,13 @@ import { OPINION_DTO_MOCK } from '@/modules/Opinion/dtoData'
 import { useParams } from 'next/navigation'
 import { useEffect, useState } from 'react'
 
-export default function useOpinionIndex(tagId?: string) {
+/**
+ * 取得首頁 / Opinion Langing 頁面的精選文章
+ * @param tagId 選擇的 tag
+ * @param limit 限制的數量
+ * @returns
+ */
+export default function useOpinionIndex(tagId?: string, limit?: number) {
   const { lang } = useParams<{ lang: Language }>()
   const landingTags = useOpinionStore((state) => state.landingTags)
 
@@ -17,18 +23,20 @@ export default function useOpinionIndex(tagId?: string) {
   /** 每一次點選不同的 categoryId 時，都會重新取得資料 */
   useEffect(() => {
     // TODO: 從 API 取得資料
+    let opinions: Opinion[] = []
     if (tagId) {
-      setOpinions(
-        OPINION_DTO_MOCK.filter((opinion) => {
-          const tagSet = new Set(opinion.tags?.map((tag) => tag.id))
-          return tagSet.has(tagId)
-        }).map((dto) => Opinion.fromDTO(lang, dto))
-      )
+      opinions = OPINION_DTO_MOCK.filter((opinion) => {
+        const tagSet = new Set(opinion.tags?.map((tag) => tag.id))
+        return tagSet.has(tagId)
+      }).map((dto) => Opinion.fromDTO(lang, dto))
     } else {
-      setOpinions(OPINION_DTO_MOCK.map((dto) => Opinion.fromDTO(lang, dto)))
+      opinions = OPINION_DTO_MOCK.map((dto) => Opinion.fromDTO(lang, dto))
     }
+    setOpinions(
+      opinions.sort((a, b) => b.date?.diff(a.date) ?? 0).slice(0, limit)
+    )
     setIsOpinionsLoading(false)
-  }, [lang, tagId])
+  }, [lang, tagId, limit])
 
   return {
     landingTags,

--- a/src/modules/Opinion/providers/OpinionStoreProvider.tsx
+++ b/src/modules/Opinion/providers/OpinionStoreProvider.tsx
@@ -8,7 +8,7 @@ import { getOpinionCategories } from '@/modules/Opinion/data'
 import { useParams } from 'next/navigation'
 import { useEffect } from 'react'
 
-export default function CategoryProvider() {
+export default function OpinionStoreProvider() {
   const { lang } = useParams<{ lang: Language }>()
 
   const setLandingTags = useOpinionStore((state) => state.setLandingTags)


### PR DESCRIPTION
## Summary

- 首頁的 opinion 限制數量為 3 及根據發佈時間 `createAt` 排序

## Test Plan

![CleanShot 2024-12-20 at 17 45 22@2x](https://github.com/user-attachments/assets/0508b641-f952-497c-abae-aba09ca4f6b0)


## Task

https://dev.azure.com/ustw/US%20Taiwan%20Watch/_backlogs/backlog/Try%20Tech/Requirements?workitem=178