### PR TITLE
feat: current congress number util & people latest exp year congress conflict

### DIFF
--- a/src/common/assets/constants.ts
+++ b/src/common/assets/constants.ts
@@ -1,2 +1,0 @@
-export const CONGRESS_NUMBER_MIN = 96
-export const CURRENT_CONGRESS_NUMBER = 118

--- a/src/common/classes/Congress.ts
+++ b/src/common/classes/Congress.ts
@@ -1,12 +1,10 @@
-// TODO: 先簡單設計給People使用
-
-import { CURRENT_CONGRESS_NUMBER } from '@/common/assets/constants'
 import { Party } from '@/common/enums/Party'
 import { isMap, isNumber } from 'lodash-es'
 import {
   Maybe,
   People_CongressionalData as PeopleCongressionalDataDTO,
 } from '@/common/lib/graphql/__generated__/graphql'
+import dayjs from 'dayjs'
 
 interface CongressArgs {
   congressNumber?: number
@@ -18,6 +16,9 @@ interface CongressArgs {
   senateDistribution?: Map<Party, number>
 }
 
+/**
+ * 管理國會資料
+ */
 export class Congress {
   // 屆數
   congressNumber?: number
@@ -58,10 +59,41 @@ export class Congress {
     }
   }
 
-  static CurrentCongressNumber = CURRENT_CONGRESS_NUMBER
-
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   static fromPeopleCongressDTO(dto?: Maybe<PeopleCongressionalDataDTO>) {
     return new Congress({})
+  }
+
+  /**
+   * 取得目前國會屆數
+   * @returns 目前國會屆數
+   */
+  static getCurrentCongressNumber() {
+    const baseYear = 1789 // 第一屆國會開始年份
+    const baseNumber = 1 // 第一屆國會屆數
+
+    const today = dayjs()
+    const currentYear = today.year()
+    const currentMonth = today.month() // 0-11
+    const currentDay = today.date() // 1-31
+
+    // 計算從基準年到現在過了幾個兩年期
+    let congressNumber = Math.floor((currentYear - baseYear) / 2) + baseNumber
+
+    // 如果現在是 1月1日 或 1月2日，要減一屆
+    // 因為新的國會要到 1月3日 才就職
+    if (currentMonth === 0 && currentDay < 3) {
+      congressNumber--
+    }
+
+    return congressNumber
+  }
+
+  /**
+   * 取得國會屆數最小值，站內提供資訊的最小國會屆數，不代表現實
+   * @returns 國會屆數最小值
+   */
+  static minCongressNumber() {
+    return 96
   }
 }

--- a/src/modules/Bill/components/BillFilter/schema.ts
+++ b/src/modules/Bill/components/BillFilter/schema.ts
@@ -5,10 +5,7 @@ import {
   BillStatusEnum,
   BillSorterEnum,
 } from '@/modules/Bill/components/BillFilter/enums'
-import {
-  CONGRESS_NUMBER_MIN,
-  CURRENT_CONGRESS_NUMBER,
-} from '@/common/assets/constants'
+import { Congress } from '@/common/classes/Congress'
 
 export const categorySchema = z.array(z.string())
 
@@ -17,7 +14,10 @@ export const partySchema = z.array(z.nativeEnum(BillPartyEnum))
 export const typeSchema = z.array(z.nativeEnum(BillTypeEnum))
 
 export const congressSchema = z.array(
-  z.number().min(CONGRESS_NUMBER_MIN).max(CURRENT_CONGRESS_NUMBER)
+  z
+    .number()
+    .min(Congress.minCongressNumber())
+    .max(Congress.getCurrentCongressNumber())
 )
 
 export const statusSchema = z.array(z.nativeEnum(BillStatusEnum))

--- a/src/modules/Bill/components/BillFilter/useBillFilterOptions.tsx
+++ b/src/modules/Bill/components/BillFilter/useBillFilterOptions.tsx
@@ -1,9 +1,5 @@
 'use client'
 
-import {
-  CONGRESS_NUMBER_MIN,
-  CURRENT_CONGRESS_NUMBER,
-} from '@/common/assets/constants'
 import { Language } from '@/common/lib/i18n/types'
 import {
   BillPartyEnum,
@@ -18,6 +14,7 @@ import { useMemo } from 'react'
 import { findAllPeople } from '@/modules/People/data'
 import { People } from '@/modules/People/classes/People'
 import TagUtils from '@/modules/Common/Tag.utils'
+import { Congress } from '@/common/classes/Congress'
 
 export type BillFilterOption<T> = {
   value: T
@@ -106,16 +103,22 @@ export default function useBillFilterOptions() {
     []
   )
 
+  const currentCongressNumber = useMemo(
+    () => Congress.getCurrentCongressNumber(),
+    []
+  )
   const congressOptions = useMemo<BillFilterOption<number>[]>(
     () =>
       Array.from(
-        { length: CURRENT_CONGRESS_NUMBER - CONGRESS_NUMBER_MIN + 1 },
-        (_, i) => i + CONGRESS_NUMBER_MIN
+        {
+          length: currentCongressNumber - Congress.minCongressNumber() + 1,
+        },
+        (_, i) => i + Congress.minCongressNumber()
       ).map((congress) => ({
         value: congress,
         label: congress.toString(),
       })),
-    []
+    [currentCongressNumber]
   )
 
   const sponsorsOptions = useMemo<BillFilterOption<string>[]>(

--- a/src/modules/Bill/components/BillLanding/BillListSection.tsx
+++ b/src/modules/Bill/components/BillLanding/BillListSection.tsx
@@ -7,13 +7,18 @@ import { SectionTitleWithLink } from '@/common/components/elements/Landing/Secti
 import BillCardCarousel from '@/modules/Bill/components/BillCardCarousel'
 import { Stack } from '@mui/material'
 import { ROUTES } from '@/routes'
-import { CURRENT_CONGRESS_NUMBER } from '@/common/assets/constants'
 import { BillSorterEnum } from '@/modules/Bill/components/BillFilter/enums'
 import { useParams } from 'next/navigation'
 import { Language } from '@/common/lib/i18n/types'
 import { getLatestBills, getPopularBills } from '@/modules/Bill/data'
+import { Congress } from '@/common/classes/Congress'
+import { useMemo } from 'react'
 
 const BillListSection = () => {
+  const currentCongressNumber = useMemo(
+    () => Congress.getCurrentCongressNumber(),
+    []
+  )
   const theme = useTheme<USTWTheme>()
   const { lang } = useParams<{ lang: Language }>()
   const latestBills = getLatestBills(lang)
@@ -33,7 +38,7 @@ const BillListSection = () => {
           link={{
             pathname: ROUTES.BILL_LIST,
             query: {
-              congress: CURRENT_CONGRESS_NUMBER,
+              congress: currentCongressNumber,
               sorter: BillSorterEnum.LatestAction,
             },
           }}

--- a/src/modules/Bill/components/BillLanding/Introduction.tsx
+++ b/src/modules/Bill/components/BillLanding/Introduction.tsx
@@ -1,12 +1,13 @@
 'use client'
 
-import { CURRENT_CONGRESS_NUMBER } from '@/common/assets/constants'
+import { Congress } from '@/common/classes/Congress'
 import UHStack from '@/common/components/atoms/UHStack'
 import { USTWTheme, styled } from '@/common/lib/mui/theme'
 import { getCurrentCongressBillCount } from '@/modules/Bill/data'
 import { ROUTES } from '@/routes'
 import { Stack, Typography, useTheme } from '@mui/material'
 import Link from 'next/link'
+import { useMemo } from 'react'
 
 const StyledBillTotalCountCard = styled(Stack)(({ theme }) => ({
   padding: theme.spacing(3, 4),
@@ -20,6 +21,10 @@ const StyledBillTotalCountCard = styled(Stack)(({ theme }) => ({
 export default function Introduction() {
   const theme = useTheme<USTWTheme>()
   const { totalDocs: billCount } = getCurrentCongressBillCount()
+  const currentCongressNumber = useMemo(
+    () => Congress.getCurrentCongressNumber(),
+    []
+  )
 
   return (
     <UHStack alignItems="center" justifyContent="space-between" width="100%">
@@ -37,12 +42,12 @@ export default function Introduction() {
       <Link
         href={{
           pathname: ROUTES.BILL_LIST,
-          query: { congress: CURRENT_CONGRESS_NUMBER },
+          query: { congress: currentCongressNumber },
         }}
       >
         <StyledBillTotalCountCard>
           <Typography variant="buttonXS" color={theme.color.grey[2100]} mb={1}>
-            {`Congress ${CURRENT_CONGRESS_NUMBER}`}
+            {`Congress ${currentCongressNumber}`}
           </Typography>
           <Typography variant="h2">{billCount}</Typography>
         </StyledBillTotalCountCard>

--- a/src/modules/Bill/components/BillLanding/ParliamentChart.tsx
+++ b/src/modules/Bill/components/BillLanding/ParliamentChart.tsx
@@ -8,8 +8,8 @@ import { useMemo, useState } from 'react'
 import usePartyColor from '@/common/lib/Party/usePartyColor'
 import { useTheme } from '@mui/material'
 import { USTWTheme } from '@/common/lib/mui/theme'
-import { CURRENT_CONGRESS_NUMBER } from '@/common/assets/constants'
 import ChartLegend from '@/modules/Bill/components/ChartLegend'
+import { Congress } from '@/common/classes/Congress'
 
 itemSeries(Highcharts)
 
@@ -28,6 +28,10 @@ type Props = {
 
 // example: https://codesandbox.io/p/sandbox/highcharts-react-demo-forked-rlflfn?file=%2Fdemo.jsx%3A23%2C1
 export default function ParliamentChart({ data }: Props) {
+  const currentCongressNumber = useMemo(
+    () => Congress.getCurrentCongressNumber(),
+    []
+  )
   const { partyColor } = usePartyColor()
   const theme = useTheme<USTWTheme>()
 
@@ -45,8 +49,8 @@ export default function ParliamentChart({ data }: Props) {
     if (hoveredParty) {
       return `${dataPartyCountMap.get(hoveredParty)}`
     }
-    return `${CURRENT_CONGRESS_NUMBER}th`
-  }, [dataPartyCountMap, hoveredParty])
+    return `${currentCongressNumber}th`
+  }, [dataPartyCountMap, hoveredParty, currentCongressNumber])
 
   const options: Highcharts.Options = useMemo(() => {
     return {

--- a/src/modules/Bill/components/BillLanding/SponsorCard.tsx
+++ b/src/modules/Bill/components/BillLanding/SponsorCard.tsx
@@ -10,7 +10,6 @@ import { Party } from '@/common/enums/Party'
 import usePartyColor from '@/common/lib/Party/usePartyColor'
 import Link from 'next/link'
 import { ROUTES } from '@/routes'
-import { CURRENT_CONGRESS_NUMBER } from '@/common/assets/constants'
 import { useParams } from 'next/navigation'
 import { Language } from '@/common/lib/i18n/types'
 import {
@@ -18,6 +17,8 @@ import {
   getBillTopCosponsors,
   getBillTopSponsors,
 } from '@/modules/Bill/data'
+import { Congress } from '@/common/classes/Congress'
+import { useMemo } from 'react'
 
 const StyledSponsorRowContainer = styled(UHStack)(({ theme }) => ({
   padding: theme.spacing(1.5, 3, 1.5, 2),
@@ -65,6 +66,10 @@ type SponsorCardProps = {
 }
 
 export default function SponsorCard({ isCosponsor }: SponsorCardProps) {
+  const currentCongressNumber = useMemo(
+    () => Congress.getCurrentCongressNumber(),
+    []
+  )
   const { lang } = useParams<{ lang: Language }>()
   const sponsorsList = isCosponsor
     ? getBillTopCosponsors(lang)
@@ -91,7 +96,7 @@ export default function SponsorCard({ isCosponsor }: SponsorCardProps) {
             href={{
               pathname: ROUTES.BILL_LIST,
               query: {
-                congress: CURRENT_CONGRESS_NUMBER,
+                congress: currentCongressNumber,
                 ...(isCosponsor
                   ? { cosponsor: people.id }
                   : { sponsor: people.id }),

--- a/src/modules/Bill/components/BillLanding/TrendBarCharts.tsx
+++ b/src/modules/Bill/components/BillLanding/TrendBarCharts.tsx
@@ -11,11 +11,8 @@ import {
   ChartsYAxis,
   ResponsiveChartContainer,
 } from '@mui/x-charts'
-import {
-  CONGRESS_NUMBER_MIN,
-  CURRENT_CONGRESS_NUMBER,
-} from '@/common/assets/constants'
 import { useMemo, useState, useEffect } from 'react'
+import { Congress } from '@/common/classes/Congress'
 
 const xLabelFormatter = (value: number | null) => (value ? `${value}th` : '')
 
@@ -33,10 +30,14 @@ export default function TrendBarCharts({
   data,
   onBarClick,
 }: TrendBarChartsProps) {
+  const currentCongressNumber = useMemo(
+    () => Congress.getCurrentCongressNumber(),
+    []
+  )
   const theme = useTheme<USTWTheme>()
   const [congressRange, setCongressRange] = useState<number[]>([
-    CONGRESS_NUMBER_MIN,
-    CURRENT_CONGRESS_NUMBER,
+    Congress.minCongressNumber(),
+    currentCongressNumber,
   ])
   const [debouncedCongressRange, setDebouncedCongressRange] =
     useState<number[]>(congressRange)
@@ -136,8 +137,8 @@ export default function TrendBarCharts({
           value={congressRange}
           onChange={handleSliderChange}
           valueLabelDisplay="auto"
-          min={CONGRESS_NUMBER_MIN}
-          max={CURRENT_CONGRESS_NUMBER}
+          min={Congress.minCongressNumber()}
+          max={currentCongressNumber}
           color="secondary"
         />
       </Box>

--- a/src/modules/Bill/components/BillVoteCard.tsx
+++ b/src/modules/Bill/components/BillVoteCard.tsx
@@ -3,12 +3,12 @@
 import UHeightLimitedText from '@/common/components/atoms/UHeightLimitedText'
 import UHStack from '@/common/components/atoms/UHStack'
 import { styled, USTWTheme } from '@/common/lib/mui/theme'
-import { CURRENT_CONGRESS_NUMBER } from '@/common/assets/constants'
 import { Stack, Typography, useTheme } from '@mui/material'
 import UCategoryTag from '@/common/components/atoms/UCategoryTag'
 import Link from 'next/link'
 import UTagList from '@/common/components/atoms/UTagList'
 import { People } from '@/modules/People/classes/People'
+import { Congress } from '@/common/classes/Congress'
 
 interface VoteStatusCardProps {
   vote: NonNullable<People['votes']>[number]
@@ -85,7 +85,7 @@ export default function BillVoteCard({ vote }: BillVoteCardProps) {
           />
 
           <Typography variant="body" fontWeight={300} mb={1}>
-            {`${vote.vote?.bill?.chamberPrefix} | ${CURRENT_CONGRESS_NUMBER}th Congress`}
+            {`${vote.vote?.bill?.chamberPrefix} | ${Congress.getCurrentCongressNumber()}th Congress`}
           </Typography>
 
           <Link href={vote.vote?.bill?.link ?? ''}>

--- a/src/modules/Bill/components/IndexBillCard/LeftSection.tsx
+++ b/src/modules/Bill/components/IndexBillCard/LeftSection.tsx
@@ -5,7 +5,6 @@ import UHStack from '@/common/components/atoms/UHStack'
 import UTimeline from '@/common/components/atoms/UTimeline'
 import { USTWTheme } from '@/common/lib/mui/theme'
 import { Bill } from '@/modules/Bill/classes/Bill'
-import { CURRENT_CONGRESS_NUMBER } from '@/common/assets/constants'
 import { Box, Stack, Typography, useTheme } from '@mui/material'
 import UCategoryTag from '@/common/components/atoms/UCategoryTag'
 import { BillStatusEnum } from '@/modules/Bill/enums/BillStatus'
@@ -13,7 +12,8 @@ import UCardInfo from '@/common/components/atoms/UCardInfo'
 import Link from 'next/link'
 import UTagList from '@/common/components/atoms/UTagList'
 import withSelectable from '@/common/hooks/withSelectable'
-import { type ComponentProps } from 'react'
+import { useMemo, type ComponentProps } from 'react'
+import { Congress } from '@/common/classes/Congress'
 
 const UTagListWithSelectable = withSelectable<ComponentProps<typeof UTagList>>(
   UTagList,
@@ -34,6 +34,10 @@ type Props = {
 
 export default function LeftSection({ bill }: Props) {
   const theme = useTheme<USTWTheme>()
+  const currentCongressNumber = useMemo(
+    () => Congress.getCurrentCongressNumber(),
+    []
+  )
 
   return (
     <Stack justifyContent="space-between" height="100%">
@@ -54,7 +58,7 @@ export default function LeftSection({ bill }: Props) {
           sx={{ color: theme.color.grey[2400] }}
           mb={1}
         >
-          {`${bill.chamberPrefix} | ${CURRENT_CONGRESS_NUMBER}th Congress`}
+          {`${bill.chamberPrefix} | ${currentCongressNumber}th Congress`}
         </TypographyWithSelectable>
 
         <Link href={bill.link}>

--- a/src/modules/Bill/components/SingleBill/TitleVersionDialog.tsx
+++ b/src/modules/Bill/components/SingleBill/TitleVersionDialog.tsx
@@ -18,11 +18,11 @@ import {
   useTheme,
 } from '@mui/material'
 import { Bill } from '@/modules/Bill/classes/Bill'
-import { CURRENT_CONGRESS_NUMBER } from '@/common/assets/constants'
 import UHStack from '@/common/components/atoms/UHStack'
 import KeyboardArrowUpOutlinedIcon from '@mui/icons-material/KeyboardArrowUpOutlined'
 import KeyboardArrowDownOutlinedIcon from '@mui/icons-material/KeyboardArrowDownOutlined'
-import { useState } from 'react'
+import { useMemo, useState } from 'react'
+import { Congress } from '@/common/classes/Congress'
 
 const FAKE_PREVIOUS_TITLES = [
   'Deterring Communist Chinese Aggression Against Taiwan Through Financial Sanctions Act of 2021',
@@ -93,6 +93,10 @@ export default function TitleVersionDialog({
   handleCloseModal,
 }: Props) {
   const theme = useTheme<USTWTheme>()
+  const currentCongressNumber = useMemo(
+    () => Congress.getCurrentCongressNumber(),
+    []
+  )
 
   return (
     <UContentCardDialog
@@ -132,7 +136,7 @@ export default function TitleVersionDialog({
           }}
         >
           <Typography variant="articleH4">
-            {`${bill.chamberPrefix}${bill.id} | ${CURRENT_CONGRESS_NUMBER}th Congress (2023-2024)`}
+            {`${bill.chamberPrefix}${bill.id} | ${currentCongressNumber}th Congress (2023-2024)`}
           </Typography>
           {FAKE_PREVIOUS_TITLES.map((title, index) => (
             <TitleRow

--- a/src/modules/People/components/PeopleCongressTitle.tsx
+++ b/src/modules/People/components/PeopleCongressTitle.tsx
@@ -1,3 +1,4 @@
+import { Congress } from '@/common/classes/Congress'
 import { type CongressExperienceRange } from '@/modules/People/classes/People'
 import { Typography } from '@mui/material'
 import dayjs from 'dayjs'
@@ -10,12 +11,23 @@ interface PeopleCongressTitleProps {
 const PeopleCongressTitle = function PeopleCongressTitle({
   congressExperienceRange,
 }: PeopleCongressTitleProps) {
+  const currentCongressNumber = useMemo(
+    () => Congress.getCurrentCongressNumber(),
+    []
+  )
   const isPresent = useMemo(() => {
     // 如果沒有 end，代表還在任職中，所以取目前年份
     if (!congressExperienceRange.latestCongressYear) return true
     // 如果 end 是現在，代表還在任職中，所以取目前年份
-    return congressExperienceRange.latestCongressYear === dayjs().year()
-  }, [congressExperienceRange])
+    const isLatestCongressYearPresent =
+      congressExperienceRange.latestCongressYear === dayjs().year()
+    if (
+      isLatestCongressYearPresent &&
+      congressExperienceRange.latestCongress === currentCongressNumber
+    )
+      return true
+    return false
+  }, [congressExperienceRange, currentCongressNumber])
 
   if (
     !congressExperienceRange.earliestCongress ||

--- a/src/modules/People/components/PeopleCongressTitle.tsx
+++ b/src/modules/People/components/PeopleCongressTitle.tsx
@@ -18,9 +18,10 @@ const PeopleCongressTitle = function PeopleCongressTitle({
   const isPresent = useMemo(() => {
     // 如果沒有 end，代表還在任職中，所以取目前年份
     if (!congressExperienceRange.latestCongressYear) return true
-    // 如果 end 是現在，代表還在任職中，所以取目前年份
+    // 最新國會年份為今年
     const isLatestCongressYearPresent =
       congressExperienceRange.latestCongressYear === dayjs().year()
+    // 如果最新的國會屆數是目前國會屆數，代表還在任職中
     if (
       isLatestCongressYearPresent &&
       congressExperienceRange.latestCongress === currentCongressNumber

--- a/src/modules/People/components/PeopleFilter/schema.ts
+++ b/src/modules/People/components/PeopleFilter/schema.ts
@@ -5,11 +5,10 @@ import {
   PeopleCategoryEnum,
   PeoplePartyEnum,
 } from '@/modules/People/components/PeopleFilter/enums'
-import {
-  CURRENT_CONGRESS_NUMBER,
-  CONGRESS_NUMBER_MIN,
-} from '@/common/assets/constants'
 import { KeysOfUnion } from '@/common/types/common'
+import { Congress } from '@/common/classes/Congress'
+
+const currentCongressNumber = Congress.getCurrentCongressNumber()
 
 const congressSchema = z.array(
   z.union([
@@ -17,9 +16,11 @@ const congressSchema = z.array(
     z
       .string()
       .transform((val) => parseInt(val, 10))
-      .pipe(z.number().min(CONGRESS_NUMBER_MIN).max(CURRENT_CONGRESS_NUMBER)),
+      .pipe(
+        z.number().min(Congress.minCongressNumber()).max(currentCongressNumber)
+      ),
     // Maybe number
-    z.number().min(CONGRESS_NUMBER_MIN).max(CURRENT_CONGRESS_NUMBER),
+    z.number().min(Congress.minCongressNumber()).max(currentCongressNumber),
   ])
 )
 

--- a/src/modules/People/components/PeopleFilter/usePeopleFilterOptions.ts
+++ b/src/modules/People/components/PeopleFilter/usePeopleFilterOptions.ts
@@ -7,10 +7,7 @@ import {
 } from '@/modules/People/components/PeopleFilter/enums'
 import states from '@/common/assets/states'
 import territoriesRegions from '@/common/assets/territories-regions'
-import {
-  CURRENT_CONGRESS_NUMBER,
-  CONGRESS_NUMBER_MIN,
-} from '@/common/assets/constants'
+import { Congress } from '@/common/classes/Congress'
 
 export type PeopleFilterOption<T> = {
   value: T
@@ -41,16 +38,21 @@ export default function usePeopleFilterOptions() {
     []
   )
 
+  const currentCongressNumber = useMemo(
+    () => Congress.getCurrentCongressNumber(),
+    []
+  )
+
   const congressOptions = useMemo<PeopleFilterOption<number>[]>(
     () =>
       Array.from(
-        { length: CURRENT_CONGRESS_NUMBER - CONGRESS_NUMBER_MIN + 1 },
-        (_, i) => i + CONGRESS_NUMBER_MIN
+        { length: currentCongressNumber - Congress.minCongressNumber() + 1 },
+        (_, i) => i + Congress.minCongressNumber()
       ).map((congress) => ({
         value: congress,
         label: congress.toString(),
       })),
-    []
+    [currentCongressNumber]
   )
 
   const stateOptions = useMemo<PeopleFilterOption<string>[]>(


### PR DESCRIPTION
## Summary

- 計算現任國會屆數 utils
- 解決 People `Present` 的計算邏輯，如果最新國會年為今年，但最新國會屆數非當前國會屆數，顯示今年年份

## Test Plan

![CleanShot 2024-12-30 at 23 44 29](https://github.com/user-attachments/assets/8111a996-6089-4565-9b65-6f3634230f7f)

屆數對不上時

![CleanShot 2024-12-30 at 23 45 12](https://github.com/user-attachments/assets/85ac91f8-c671-4ceb-b64d-2dd1f2525680)


## Task

