### PR TITLE
fix: People congress exp range

### DIFF
--- a/src/modules/People/components/PeopleCongressTitle.tsx
+++ b/src/modules/People/components/PeopleCongressTitle.tsx
@@ -13,6 +13,7 @@ const PeopleCongressTitle = function PeopleCongressTitle({
   const isPresent = useMemo(() => {
     // 如果沒有 end，代表還在任職中，所以取目前年份
     if (!congressExperienceRange.latestCongressYear) return true
+    // 如果最新的國會年份為今年，代表還在任職中
     if (congressExperienceRange.latestCongressYear === dayjs().year())
       return true
     return false

--- a/src/modules/People/components/PeopleCongressTitle.tsx
+++ b/src/modules/People/components/PeopleCongressTitle.tsx
@@ -1,4 +1,3 @@
-import { Congress } from '@/common/classes/Congress'
 import { type CongressExperienceRange } from '@/modules/People/classes/People'
 import { Typography } from '@mui/material'
 import dayjs from 'dayjs'
@@ -11,24 +10,13 @@ interface PeopleCongressTitleProps {
 const PeopleCongressTitle = function PeopleCongressTitle({
   congressExperienceRange,
 }: PeopleCongressTitleProps) {
-  const currentCongressNumber = useMemo(
-    () => Congress.getCurrentCongressNumber(),
-    []
-  )
   const isPresent = useMemo(() => {
     // 如果沒有 end，代表還在任職中，所以取目前年份
     if (!congressExperienceRange.latestCongressYear) return true
-    // 最新國會年份為今年
-    const isLatestCongressYearPresent =
-      congressExperienceRange.latestCongressYear === dayjs().year()
-    // 如果最新的國會屆數是目前國會屆數，代表還在任職中
-    if (
-      isLatestCongressYearPresent &&
-      congressExperienceRange.latestCongress === currentCongressNumber
-    )
+    if (congressExperienceRange.latestCongressYear === dayjs().year())
       return true
     return false
-  }, [congressExperienceRange, currentCongressNumber])
+  }, [congressExperienceRange])
 
   if (
     !congressExperienceRange.earliestCongress ||


### PR DESCRIPTION
## Summary

congress experience 只考慮後端回應的 start/end，沒有 end 即為任職中，因此沒有 end 即為今年

## Test Plan

![CleanShot 2025-01-02 at 23 46 36](https://github.com/user-attachments/assets/71de4d0c-5da1-4b67-9d4b-48a4806d909f)


## Task
