### PR TITLE
fix: show featured bills on landing page and remove latest action cha…

### DIFF
--- a/src/modules/Bill/components/BillCardCarousel.tsx
+++ b/src/modules/Bill/components/BillCardCarousel.tsx
@@ -4,7 +4,6 @@ import Carousel from '@/common/components/elements/Carousel'
 import { styled } from '@/common/lib/mui/theme'
 import { Box, Container } from '@mui/material'
 import BillCard from '@/modules/Bill/components/BillCard'
-import { BILL_DATA_MOCK } from '@/modules/Bill/data'
 import UFullWidthBackgroundBox from '@/common/components/atoms/UFullWidthBackgroundBox'
 import ArrowPagination from '@/common/components/elements/Carousel/ArrowPagination'
 import { Bill } from '@/modules/Bill/classes/Bill'
@@ -23,13 +22,10 @@ const StyledCarouselContainer = styled(UFullWidthBackgroundBox)(() => ({
 
 type Props = {
   simplified?: boolean
-  data?: Bill[]
+  data: Bill[]
 }
 
-export default function BillCardCarousel({
-  simplified,
-  data = BILL_DATA_MOCK,
-}: Props) {
+export default function BillCardCarousel({ simplified, data }: Props) {
   return (
     <StyledCarouselContainer>
       <Container maxWidth="lg">

--- a/src/modules/Bill/components/IndexBillCard/RightSection.tsx
+++ b/src/modules/Bill/components/IndexBillCard/RightSection.tsx
@@ -21,7 +21,6 @@ import Image from 'next/image'
 import UHStack from '@/common/components/atoms/UHStack'
 import { ReactNode } from 'react'
 import dayjs from 'dayjs'
-import UCategoryTag from '@/common/components/atoms/UCategoryTag'
 import UHeightLimitedText from '@/common/components/atoms/UHeightLimitedText'
 import usePartyColor from '@/common/lib/Party/usePartyColor'
 import { Party } from '@/common/enums/Party'
@@ -190,28 +189,15 @@ export default function RightSection({ bill }: Props) {
           <CardIconTitle icon={<ActionsIcon />} title="Latest Action" />
           <Divider sx={{ my: 2, borderWidth: 1 }} />
           <Stack gap={1.5}>
-            <UHStack justifyContent="space-between" alignItems="center">
-              <UCategoryTag
-                value={bill.latestAction?.chamber}
-                containerProps={{
-                  sx: {
-                    backgroundColor: `${theme.color.purple[100]}80`, // 50% opacity
-                  },
-                }}
-                textProps={{
-                  variant: 'buttonS',
-                }}
-              />
-              <Typography
-                variant="buttonXS"
-                fontSize={15}
-                sx={{ color: theme.color.grey[1200] }}
-              >
-                {dayjs(bill.latestAction?.date).isValid()
-                  ? dayjs(bill.latestAction?.date).format(ACTION_DATE_FORMAT)
-                  : ''}
-              </Typography>
-            </UHStack>
+            <Typography
+              variant="buttonXS"
+              fontSize={15}
+              sx={{ color: theme.color.grey[1200] }}
+            >
+              {dayjs(bill.latestAction?.date).isValid()
+                ? dayjs(bill.latestAction?.date).format(ACTION_DATE_FORMAT)
+                : ''}
+            </Typography>
             <UHeightLimitedText maxLine={3} variant="buttonXS">
               {bill.latestAction?.description}
             </UHeightLimitedText>

--- a/src/modules/Bill/data.ts
+++ b/src/modules/Bill/data.ts
@@ -45,9 +45,9 @@ export const PARLIAMENT_CHART_DATA_MOCK_2: ParliamentChartData[] = [
   },
 ]
 
-export const BILL_DATA_MOCK: Bill[] = BILL_DTO_MOCK.map((dto) =>
-  Bill.fromDTO('en-US', dto)
-)
+export const FEATURED_BILLS: Bill[] = BILL_DTO_MOCK.filter(
+  (bill) => bill.isFeatured
+).map((dto) => Bill.fromDTO('en-US', dto))
 
 export const getCurrentCongressBillCount = (): CountBills => {
   return {

--- a/src/modules/LandingPage/components/BillSection.tsx
+++ b/src/modules/LandingPage/components/BillSection.tsx
@@ -1,18 +1,18 @@
 'use client'
 
-import { BILL_DATA_MOCK } from '@/modules/Bill/data'
 import Container from '@mui/material/Container'
 import { Stack } from '@mui/material'
 import { SectionTitleWithLink } from '@/common/components/elements/Landing/SectionTitle'
 import IndexBillCardList from '@/modules/Bill/components/IndexBillCard/IndexBillCardList'
 import { ROUTES } from '@/routes'
+import { FEATURED_BILLS } from '@/modules/Bill/data'
 
 const BillSection = () => {
   return (
     <Container maxWidth="lg">
       <Stack py={10} gap={7.5}>
         <SectionTitleWithLink title="Bills" link={ROUTES.BILL} />
-        <IndexBillCardList billData={BILL_DATA_MOCK} />
+        <IndexBillCardList billData={FEATURED_BILLS} />
       </Stack>
     </Container>
   )


### PR DESCRIPTION
## Summary

Landing Page 的 Bill Cards 只顯示 isFeatured 的 bills，並比照其他地方的 Bill Card 將 latest action 的 chamber chip 給移除

## Test Plan

https://github.com/user-attachments/assets/53a018b8-13d1-4506-a871-928184df9ea8

## Task

https://dev.azure.com/ustw/US%20Taiwan%20Watch/_workitems/edit/178