### PR TITLE
fix: people fix

### DIFF
--- a/src/common/components/elements/IdeologyLeadershipChart/index.tsx
+++ b/src/common/components/elements/IdeologyLeadershipChart/index.tsx
@@ -95,15 +95,16 @@ const IdeologyLeadershipChart = function IdeologyLeadershipChart({
                 fillColor: theme.color.pink[1000],
                 radius: 8,
               },
+              zIndex: 10,
             }
             return null
           } else {
             return {
               x: Number(item.ideology),
               y: Number(item.leadership),
-              // TODO: Sen. John Cornyn
               name: item.name,
               item,
+              zIndex: 1,
             }
           }
         }),

--- a/src/common/styles/assets/BookmarkIcon.svg
+++ b/src/common/styles/assets/BookmarkIcon.svg
@@ -1,3 +1,3 @@
-<svg viewBox="0 0 13 15" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M1.16211 2C1.16211 1.44772 1.60982 1 2.16211 1H11.1621C11.7144 1 12.1621 1.44772 12.1621 2V13.0091C12.1621 13.4194 11.6951 13.6551 11.365 13.4113L6.66211 9.9375L1.95918 13.4113C1.62911 13.6551 1.16211 13.4194 1.16211 13.0091V2Z" stroke="currentColor" stroke-width="1.5" stroke-linejoin="round" fill="transparent"/>
+<svg viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M15.8337 17.5L10.0003 14.1667L4.16699 17.5V4.16667C4.16699 3.72464 4.34259 3.30072 4.65515 2.98816C4.96771 2.67559 5.39163 2.5 5.83366 2.5H14.167C14.609 2.5 15.0329 2.67559 15.3455 2.98816C15.6581 3.30072 15.8337 3.72464 15.8337 4.16667V17.5Z" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" fill="transparent"/>
 </svg>

--- a/src/modules/People/components/PeopleCongressTitle.tsx
+++ b/src/modules/People/components/PeopleCongressTitle.tsx
@@ -30,8 +30,8 @@ const PeopleCongressTitle = function PeopleCongressTitle({
     <Typography variant="bodyS" fontWeight={600}>
       {/** TODO i18n */}
       {`${congressExperienceRange.earliestCongress}th 
-      - ${congressExperienceRange.latestCongress}th Congress 
-      (${congressExperienceRange.earliestCongressYear}
+      - ${congressExperienceRange.latestCongress}th Congress
+       (${congressExperienceRange.earliestCongressYear}
       -${isPresent ? 'Present' : (congressExperienceRange.latestCongressYear ?? '')})`}
     </Typography>
   )

--- a/src/modules/People/components/PeopleTracker/CardContent/IdeologyLeadershipChart.tsx
+++ b/src/modules/People/components/PeopleTracker/CardContent/IdeologyLeadershipChart.tsx
@@ -1,4 +1,3 @@
-import { LineChartIcon } from '@/common/styles/assets/Icons'
 import UContentCard from '@/common/components/atoms/UContentCard'
 import IdeologyLeadershipChartElement from '@/common/components/elements/IdeologyLeadershipChart'
 import data from '@/modules/People/assets/data/ideology.json'
@@ -16,12 +15,9 @@ const IdeologyLeadershipChart = function IdeologyLeadershipChart({
 
   return (
     <UContentCard
-      headerIconAction="modal"
       withHeader
       headerProps={{
         title: 'Ideology-Leadership Chart',
-        icon: <LineChartIcon />,
-        iconColor: 'secondary',
       }}
     >
       <IdeologyLeadershipChartElement activeId={activeId} data={data} />

--- a/src/modules/People/components/PeopleTracker/PeopleInfoSection.tsx
+++ b/src/modules/People/components/PeopleTracker/PeopleInfoSection.tsx
@@ -11,6 +11,7 @@ import {
   InstagramIcon,
   XIcon,
   YoutubeIcon,
+  BookmarkIcon,
 } from '@/common/styles/assets/Icons'
 import { People } from '@/modules/People/classes/People'
 import PeopleCategory from '@/modules/People/components/PeopleCategory'
@@ -93,7 +94,7 @@ const LinkMenuActivator = memo(function LinkMenuActivator({
       <StyledLinkButton
         id="link-button"
         variant="contained"
-        startIcon={<LinkIcon width={24} height={24} />}
+        startIcon={<LinkIcon sx={{ width: 16 }} />}
         rounded
         onClick={handleLinkBtnClick}
       >
@@ -186,7 +187,12 @@ const PeopleInfoSection = memo(function PeopleInfoSection({
       {/** Actions */}
       <UHStack spacing={2}>
         <LinkMenuActivator people={people} />
-        <StyledSubscribeButton variant="contained" color="primary" rounded>
+        <StyledSubscribeButton
+          variant="contained"
+          color="primary"
+          rounded
+          startIcon={<BookmarkIcon sx={{ width: 16 }} />}
+        >
           Subscribe
         </StyledSubscribeButton>
       </UHStack>

--- a/src/modules/TaiwanRecord/components/TaiwanRecordCard.tsx
+++ b/src/modules/TaiwanRecord/components/TaiwanRecordCard.tsx
@@ -41,7 +41,7 @@ const TaiwanRecordCard = ({ taiwanRecord }: TaiwanRecordCardProps) => {
   }, [taiwanRecord])
 
   return (
-    <UAccordion expanded>
+    <UAccordion defaultExpanded>
       <AccordionSummary
         expandIcon={<ExpandMoreIcon width={24} height={24} />}
         aria-controls="panel1-content"

--- a/src/modules/TaiwanRecord/components/TaiwanRecordSources.tsx
+++ b/src/modules/TaiwanRecord/components/TaiwanRecordSources.tsx
@@ -18,6 +18,7 @@ import Button from '@mui/material/Button'
 import Link from 'next/link'
 import Divider from '@mui/material/Divider'
 import { getLinkPreview } from 'link-preview-js'
+import { LinkIcon } from '@/common/styles/assets/Icons'
 
 type SourceMetadata = {
   /** 連結 */
@@ -119,7 +120,7 @@ const SourcesDialog = memo(function SourcesDialog(props: SourcesDialogProps) {
                 >
                   <UHStack gap={1} alignItems="center">
                     <Avatar src={m.favicon} sx={{ width: 16, height: 16 }}>
-                      {m.siteName.slice(0, 1)}
+                      <LinkIcon sx={{ width: 12, height: 12 }} />
                     </Avatar>
                     <Typography variant="body2">{m.siteName}</Typography>
                   </UHStack>
@@ -203,7 +204,7 @@ const TaiwanRecordSources = ({ sources }: TaiwanRecordSourcesProps) => {
               alt={new URL(sources.links[index]).hostname}
               src={m.favicon}
             >
-              {m.siteName.slice(0, 1)}
+              <LinkIcon sx={{ width: 12, height: 12 }} />
             </Avatar>
           ))}
         </AvatarGroup>


### PR DESCRIPTION
## Summary

- [People][Filter Page] 議員的任期西元時間少一個空白
- [People][Person Page] 沒有加到 Subscribe 的 Icon
- [People][Person Page] Ideology-Leadership Chart 顯示
  - 凸顯三角形
  - 拿掉箭頭
- [People][Person Page] Taiwan Record 顯示
  - accordion 收折
  - link favicon default icon

## Test Plan

![CleanShot 2025-02-06 at 00 13 06](https://github.com/user-attachments/assets/a2083f62-5792-436d-9d78-c24c2b6c1b52)

![CleanShot 2025-02-06 at 00 13 37](https://github.com/user-attachments/assets/47bf5252-a4ce-4cb6-94c1-c4c8d4af05c4)

![CleanShot 2025-02-06 at 00 13 44](https://github.com/user-attachments/assets/8c6aee5a-6399-42fa-a0db-8b71cfafdf9b)


https://github.com/user-attachments/assets/cfc49025-4ef2-4fa9-ad48-bbb52601178a


## Task

https://dev.azure.com/ustw/US%20Taiwan%20Watch/_workitems/edit/213/
https://dev.azure.com/ustw/US%20Taiwan%20Watch/_workitems/edit/217/
https://dev.azure.com/ustw/US%20Taiwan%20Watch/_workitems/edit/223/
https://dev.azure.com/ustw/US%20Taiwan%20Watch/_workitems/edit/224/