### PR TITLE
Bill UI fix

### DIFF
--- a/src/modules/Bill/classes/Bill.ts
+++ b/src/modules/Bill/classes/Bill.ts
@@ -355,10 +355,12 @@ export class Bill {
       }
     )
 
-    return Object.entries(parliamentMap).map(([party, count]) => ({
-      party: party as Party,
-      count,
-    }))
+    return Object.entries(parliamentMap)
+      .map(([party, count]) => ({
+        party: party as Party,
+        count,
+      }))
+      .sort((a, b) => b.count - a.count)
   }
 
   static getRelatedBills(dto: BillDTO, lang: Language): Bill[] {

--- a/src/modules/Bill/components/BillLanding/TrendBarCharts.tsx
+++ b/src/modules/Bill/components/BillLanding/TrendBarCharts.tsx
@@ -95,7 +95,12 @@ export default function TrendBarCharts({
             valueFormatter: xLabelFormatter,
           },
         ]}
-        yAxis={[{ label: 'Bill Count' }]}
+        yAxis={[
+          {
+            label: 'Bill Count',
+            tickMinStep: 1,
+          },
+        ]}
         series={[
           {
             type: 'bar',
@@ -140,6 +145,16 @@ export default function TrendBarCharts({
           min={Congress.minCongressNumber()}
           max={currentCongressNumber}
           color="secondary"
+          marks={[
+            {
+              value: Congress.minCongressNumber(),
+              label: `${Congress.minCongressNumber()}th`,
+            },
+            {
+              value: currentCongressNumber,
+              label: `${currentCongressNumber}th`,
+            },
+          ]}
         />
       </Box>
     </>

--- a/src/modules/Bill/components/SingleBill/CosponsorDialog/CosponsorTable.tsx
+++ b/src/modules/Bill/components/SingleBill/CosponsorDialog/CosponsorTable.tsx
@@ -17,6 +17,7 @@ import UHStack from '@/common/components/atoms/UHStack'
 import dayjs from 'dayjs'
 import { BillCosponsor } from '@/modules/People/classes/BillCosponsor'
 import CommonUtils from '@/modules/Common/Common.utils'
+import Link from 'next/link'
 
 const EMPTY_CELL = '-'
 
@@ -72,9 +73,11 @@ export default function CosponsorTable({ cosponsors }: Props) {
                 sx={{ '&:last-child td, &:last-child th': { border: 0 } }}
               >
                 <TableCell component="th" scope="row">
-                  <StyledNameText>
-                    {people?.name ? people.name : EMPTY_CELL}
-                  </StyledNameText>
+                  <Link href={people?.link ?? ''}>
+                    <StyledNameText>
+                      {people?.name ? people.name : EMPTY_CELL}
+                    </StyledNameText>
+                  </Link>
                 </TableCell>
                 <TableCell align="left">
                   <UHStack spacing={1} alignItems="center">

--- a/src/modules/Bill/components/SingleBill/Sponsor.tsx
+++ b/src/modules/Bill/components/SingleBill/Sponsor.tsx
@@ -6,6 +6,7 @@ import { styled } from '@/common/lib/mui/theme'
 import { Bill } from '@/modules/Bill/classes/Bill'
 import UHStack from '@/common/components/atoms/UHStack'
 import Image from 'next/image'
+import Link from 'next/link'
 
 const StyledImageContainer = styled(Box)(() => ({
   position: 'relative',
@@ -37,18 +38,22 @@ export default function Sponsor({ bill }: Props) {
     >
       <UHStack pt={2} spacing={3}>
         {bill.sponsor?.image && (
-          <StyledImageContainer>
-            <StyledImage
-              src={bill.sponsor.image}
-              alt={bill.sponsor.name ?? ''}
-              fill
-            />
-          </StyledImageContainer>
+          <Link href={bill.sponsor?.link ?? ''}>
+            <StyledImageContainer>
+              <StyledImage
+                src={bill.sponsor.image}
+                alt={bill.sponsor.name ?? ''}
+                fill
+              />
+            </StyledImageContainer>
+          </Link>
         )}
 
         <Stack justifyContent="space-between">
           <Stack spacing={1}>
-            <Typography variant="articleH3">{bill.sponsor?.name}</Typography>
+            <Link href={bill.sponsor?.link ?? ''}>
+              <Typography variant="articleH3">{bill.sponsor?.name}</Typography>
+            </Link>
             <Typography variant="body">{bill.sponsor?.position}</Typography>
           </Stack>
 


### PR DESCRIPTION
## Summary

1. bill bar chart 設定 y 軸 step 為 1，並在 slider 兩端顯示數值
2. bill sponsor 點擊圖片或名稱跳轉至 people 頁面
3. sort cosponsor chart data

## Test Plan

1. bill bar chart 設定 y 軸 step 為 1，並在 slider 兩端顯示數值
<img width="839" alt="Screenshot 2025-02-09 at 3 20 45 PM" src="https://github.com/user-attachments/assets/15328434-d7f4-4d31-a4bb-06c1ac0c8f5b" />

2. bill sponsor 點擊圖片或名稱跳轉至 people 頁面

https://github.com/user-attachments/assets/ff61fc73-3e0c-4846-aa50-31651b8ad3c7

3. sort cosponsor chart data

https://github.com/user-attachments/assets/bc66a9c7-5b18-4ab7-a683-21bf497b0be9

## Task

https://dev.azure.com/ustw/US%20Taiwan%20Watch/_workitems/edit/198
https://dev.azure.com/ustw/US%20Taiwan%20Watch/_workitems/edit/207
https://dev.azure.com/ustw/US%20Taiwan%20Watch/_workitems/edit/210