### PR TITLE
fix: bill carousel pagination

### DIFF
--- a/src/common/components/elements/Carousel/index.tsx
+++ b/src/common/components/elements/Carousel/index.tsx
@@ -25,6 +25,7 @@ export interface PaginationProps {
   handleNext?: () => void
   handleDotClick?: (index: number) => void
   showDot?: boolean
+  sliderRef?: React.RefObject<Slider>
 }
 
 interface CarouselProps {
@@ -104,6 +105,7 @@ function Carousel({
           handlePrev,
           handleNext,
           handleDotClick,
+          sliderRef,
         })
       ) : (
         <ArrowPagination

--- a/src/modules/Bill/components/BillCardCarousel.tsx
+++ b/src/modules/Bill/components/BillCardCarousel.tsx
@@ -26,6 +26,10 @@ type Props = {
 }
 
 export default function BillCardCarousel({ simplified, data }: Props) {
+  // 顯示三張的話，最後兩張不可能成為 currentSlide，故藉 availableSlideCount 控制 handleNext
+  const slidesToShow = 3
+  const availableSlideCount = data.length - (slidesToShow - 1)
+
   return (
     <StyledCarouselContainer>
       <Container maxWidth="lg">
@@ -34,12 +38,21 @@ export default function BillCardCarousel({ simplified, data }: Props) {
           settings={{
             infinite: false,
             centerPadding: '0px',
-            slidesToShow: 3,
+            slidesToShow,
             slidesToScroll: 1,
             centerMode: false,
           }}
           renderPagination={(props) => (
-            <ArrowPagination {...props} showDot={true} />
+            <ArrowPagination
+              {...props}
+              slideCount={availableSlideCount}
+              handleNext={() => {
+                if (props.currentSlide + 1 < availableSlideCount) {
+                  props.sliderRef?.current?.slickNext()
+                }
+              }}
+              showDot
+            />
           )}
         >
           {data.map((bill, index) => (


### PR DESCRIPTION
## Summary

bill carousel 原本的寫法會導致右鍵可以一路點超過 slides 範圍，修正 pagination 讓他可控制在能顯示的範圍內

## Test Plan

https://github.com/user-attachments/assets/851b5917-829f-4f18-accc-26ba07f2f49a

## Task

https://dev.azure.com/ustw/US%20Taiwan%20Watch/_workitems/edit/199