### PR TITLE
fix: wrong party and action time

### DIFF
--- a/src/modules/Bill/classes/Bill.ts
+++ b/src/modules/Bill/classes/Bill.ts
@@ -259,7 +259,10 @@ export class Bill {
         : undefined,
       title: dto.i18n?.[CommonUtils.parseAPII18nKey(lang)]?.title ?? undefined,
       sponsor: dto.sponsor?.people
-        ? People.fromDTO(lang, dto.sponsor.people)
+        ? People.fromDTO(lang, {
+            ...dto.sponsor.people,
+            currentParty: dto.sponsor.party, // 提案當下的政黨
+          })
         : undefined,
       cosponsors:
         dto.cosponsors

--- a/src/modules/Bill/components/BillCard.tsx
+++ b/src/modules/Bill/components/BillCard.tsx
@@ -4,7 +4,6 @@ import UHeightLimitedText from '@/common/components/atoms/UHeightLimitedText'
 import UHStack from '@/common/components/atoms/UHStack'
 import UPoliticalPartyIcon from '@/common/components/atoms/UPoliticalPartyIcon'
 import UTimeline from '@/common/components/atoms/UTimeline'
-import { Party } from '@/common/enums/Party'
 import { styled, USTWTheme } from '@/common/lib/mui/theme'
 import { Bill } from '@/modules/Bill/classes/Bill'
 import { Box, Divider, Stack, Typography, useTheme } from '@mui/material'
@@ -15,7 +14,7 @@ import UCardInfo from '@/common/components/atoms/UCardInfo'
 import Link from 'next/link'
 import UTagList from '@/common/components/atoms/UTagList'
 
-const DATE_FORMAT = 'MM/DD/YYYY-hh:mmA'
+const DATE_FORMAT = 'MM/DD/YYYY'
 
 const StyledCardContainer = styled(Stack)(({ theme }) => ({
   width: '100%',
@@ -95,11 +94,13 @@ export default function BillCard({ mode, simplified, bill }: Props) {
           {!isHorizontal && <Divider sx={{ mt: 3 }} />}
 
           <UHStack px={1} gap={1.5} alignItems="center" mt={2}>
-            <UPoliticalPartyIcon
-              variant="rounded"
-              party={bill.sponsor?.party ?? Party.INDEPENDENT}
-              size="small"
-            />
+            {bill.sponsor?.party && (
+              <UPoliticalPartyIcon
+                variant="rounded"
+                party={bill.sponsor.party}
+                size="small"
+              />
+            )}
             <Typography variant="subtitleS" fontWeight={700}>
               {bill.sponsor?.name}
             </Typography>
@@ -114,8 +115,9 @@ export default function BillCard({ mode, simplified, bill }: Props) {
                   variant="buttonS"
                   {...(isHorizontal && { color: theme.color.grey[400] })}
                 >
-                  {dayjs(bill.latestAction?.date).isValid()
-                    ? dayjs(bill.latestAction?.date).format(DATE_FORMAT)
+                  {bill.latestAction?.date &&
+                  dayjs(bill.latestAction.date).isValid()
+                    ? dayjs(bill.latestAction.date).format(DATE_FORMAT)
                     : ''}
                 </Typography>
                 <UHeightLimitedText maxLine={2} variant="body" fontWeight={300}>

--- a/src/modules/Bill/components/IndexBillCard/RightSection.tsx
+++ b/src/modules/Bill/components/IndexBillCard/RightSection.tsx
@@ -124,20 +124,22 @@ export default function RightSection({ bill }: Props) {
                 alt={bill.sponsor.name ?? ''}
                 fill
               />
-              <StyledPartyIconContainer>
-                <UPoliticalPartyIcon
-                  variant="rounded"
-                  size="small"
-                  party={bill.sponsor.party ?? Party.INDEPENDENT}
-                  sx={{
-                    width: '18px',
-                    height: '18px',
-                  }}
-                  customFontStyle={{
-                    fontSize: '12px',
-                  }}
-                />
-              </StyledPartyIconContainer>
+              {bill.sponsor.party && (
+                <StyledPartyIconContainer>
+                  <UPoliticalPartyIcon
+                    variant="rounded"
+                    size="small"
+                    party={bill.sponsor.party}
+                    sx={{
+                      width: '18px',
+                      height: '18px',
+                    }}
+                    customFontStyle={{
+                      fontSize: '12px',
+                    }}
+                  />
+                </StyledPartyIconContainer>
+              )}
             </StyledImageContainer>
           )}
           <Stack>

--- a/src/modules/Bill/dtoData.ts
+++ b/src/modules/Bill/dtoData.ts
@@ -6795,7 +6795,7 @@ export const BILL_DTO_MOCK = [
         actionsOverview: [
           {
             actionAt: {
-              datetime: '2014-02-10T00T00:00:00.000Z',
+              datetime: '2014-02-10T00:00:00.000Z',
               precision: ['year', 'month', 'day'],
             },
             description: 'Introduced in Senate',


### PR DESCRIPTION
## Summary

1. bill sponsor 用當時的 party 作為 people 的 party 欄位
2. bill latestAction 的 precision 看來都只有日期，故將 hh:mm 從 format 移除
3. 如果 sponsor 沒有 party，直接不顯示，因 party 有可能沒有紀錄
4. 如果 sponsor 沒有 action time，直接不顯示，避免 dayjs 初始化為當下時間

## Test Plan

https://github.com/user-attachments/assets/d9892053-d581-4758-a11a-abc91a2e396d

https://github.com/user-attachments/assets/40bdcf39-12b2-4611-bc86-1145460f232b

https://github.com/user-attachments/assets/41d2f779-6ab8-4da5-828c-107384dab81f

## Task
https://dev.azure.com/ustw/US%20Taiwan%20Watch/_workitems/edit/194
https://dev.azure.com/ustw/US%20Taiwan%20Watch/_workitems/edit/220
https://dev.azure.com/ustw/US%20Taiwan%20Watch/_workitems/edit/202
