### PR TITLE
feat: update TitleVersion, AI Summary, and expand button for cards

### DIFF
--- a/src/common/styles/assets/ExpandIcon.svg
+++ b/src/common/styles/assets/ExpandIcon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 -960 960 960" width="24px" fill="#e8eaed"><path d="M200-200v-240h80v160h160v80H200Zm480-320v-160H520v-80h240v240h-80Z"/></svg>

--- a/src/common/styles/assets/Icons.tsx
+++ b/src/common/styles/assets/Icons.tsx
@@ -44,6 +44,7 @@ import SvgPeopleJoinIcon from './PeopleJoinIcon.svg'
 import SvgExpandMoreIcon from './ExpandMoreIcon.svg'
 import SvgInternetIcon from './InternetIcon.svg'
 import SvgOpenSecretsIcon from './OpenSecretsIcon.svg'
+import SvgExpandIcon from './ExpandIcon.svg'
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const SizableSvgIcon = (props: SvgIconProps & { component: any }) => {
@@ -225,4 +226,8 @@ export const InternetIcon = (props: SvgIconProps) => (
 
 export const OpenSecretsIcon = (props: SvgIconProps) => (
   <SizableSvgIcon component={SvgOpenSecretsIcon} {...props} />
+)
+
+export const ExpandIcon = (props: SvgIconProps) => (
+  <SizableSvgIcon component={SvgExpandIcon} {...props} />
 )

--- a/src/modules/Bill/components/SingleBill/BillActions.tsx
+++ b/src/modules/Bill/components/SingleBill/BillActions.tsx
@@ -1,15 +1,13 @@
 'use client'
 import UContentCard from '@/common/components/atoms/UContentCard'
 import { ActionsIcon } from '@/common/styles/assets/Icons'
-import { Stack, Typography, useTheme } from '@mui/material'
-import ArrowForwardIcon from '@mui/icons-material/ArrowForward'
-import UIconButton from '@/common/components/atoms/UIconButton'
-import { USTWTheme } from '@/common/lib/mui/theme'
+import { Stack, Typography } from '@mui/material'
 import { Bill } from '@/modules/Bill/classes/Bill'
 import dayjs from 'dayjs'
 import UHeightLimitedText from '@/common/components/atoms/UHeightLimitedText'
 import ActionsDialog from '@/modules/Bill/components/SingleBill/ActionsDialog'
 import useModal from '@/common/hooks/useModal'
+import CardExpandButton from '@/modules/Bill/components/SingleBill/CardExpandButton'
 
 const DATE_FORMAT = 'MM/DD/YYYY'
 
@@ -18,7 +16,6 @@ type Props = {
 }
 
 export default function BillActions({ bill }: Props) {
-  const theme = useTheme<USTWTheme>()
   const { isModalOpen, handleOpenModal, handleCloseModal } = useModal()
 
   return (
@@ -29,16 +26,7 @@ export default function BillActions({ bill }: Props) {
           title: 'Actions',
           icon: <ActionsIcon />,
           iconColor: 'primary',
-          action: (
-            <UIconButton
-              variant="rounded"
-              color="inherit"
-              size="small"
-              onClick={handleOpenModal}
-            >
-              <ArrowForwardIcon sx={{ color: theme.color.neutral[500] }} />
-            </UIconButton>
-          ),
+          action: <CardExpandButton onClick={handleOpenModal} />,
         }}
       >
         <Stack pt={2}>

--- a/src/modules/Bill/components/SingleBill/BillCosponsors.tsx
+++ b/src/modules/Bill/components/SingleBill/BillCosponsors.tsx
@@ -1,21 +1,17 @@
 'use client'
 import UContentCard from '@/common/components/atoms/UContentCard'
 import { CosponsorsIcon } from '@/common/styles/assets/Icons'
-import { useTheme } from '@mui/material'
-import ArrowForwardIcon from '@mui/icons-material/ArrowForward'
-import UIconButton from '@/common/components/atoms/UIconButton'
-import { USTWTheme } from '@/common/lib/mui/theme'
 import CosponsorChart from '@/modules/Bill/components/SingleBill/CosponsorChart'
 import CosponsorDialog from '@/modules/Bill/components/SingleBill/CosponsorDialog'
 import { Bill } from '@/modules/Bill/classes/Bill'
 import useModal from '@/common/hooks/useModal'
+import CardExpandButton from '@/modules/Bill/components/SingleBill/CardExpandButton'
 
 type Props = {
   bill: Bill
 }
 
 export default function BillCosponsors({ bill }: Props) {
-  const theme = useTheme<USTWTheme>()
   const { isModalOpen, handleOpenModal, handleCloseModal } = useModal()
 
   return (
@@ -26,16 +22,7 @@ export default function BillCosponsors({ bill }: Props) {
           title: 'Cosponsors',
           icon: <CosponsorsIcon />,
           iconColor: 'primary',
-          action: (
-            <UIconButton
-              variant="rounded"
-              color="inherit"
-              size="small"
-              onClick={handleOpenModal}
-            >
-              <ArrowForwardIcon sx={{ color: theme.color.neutral[500] }} />
-            </UIconButton>
-          ),
+          action: <CardExpandButton onClick={handleOpenModal} />,
         }}
         contentProps={{
           sx: {

--- a/src/modules/Bill/components/SingleBill/BioByAI.tsx
+++ b/src/modules/Bill/components/SingleBill/BioByAI.tsx
@@ -1,51 +1,30 @@
 'use client'
 
-import UButton from '@/common/components/atoms/UButton'
 import UContentCard from '@/common/components/atoms/UContentCard'
 import { StarsIcon } from '@/common/styles/assets/Icons'
-import { Typography, useTheme } from '@mui/material'
-import ArrowForwardIcon from '@mui/icons-material/ArrowForward'
-import { USTWTheme } from '@/common/lib/mui/theme'
+import { Typography } from '@mui/material'
 import { Bill } from '@/modules/Bill/classes/Bill'
+import CardExpandButton from '@/modules/Bill/components/SingleBill/CardExpandButton'
 
 type Props = {
   bill: Bill
 }
 
 export default function BioByAI({ bill }: Props) {
-  const theme = useTheme<USTWTheme>()
-
   return (
     <UContentCard
       withHeader
+      headerIconAction="modal"
+      modalContent={
+        <Typography variant="body" pt={2}>
+          {bill.summary}
+        </Typography>
+      }
       headerProps={{
         title: 'Summary From AI',
         icon: <StarsIcon />,
         iconColor: 'primary',
-        action: (
-          <a
-            href={bill.congressGovUrl}
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <UButton
-              endIcon={
-                <ArrowForwardIcon sx={{ color: theme.color.neutral[500] }} />
-              }
-              color="info"
-              variant="outlined"
-              size="small"
-              sx={{
-                py: 0.5,
-                px: 1,
-                borderRadius: '9px',
-                border: `1.5px solid ${theme.color.grey[1400]}`,
-              }}
-            >
-              <Typography variant="buttonXS">Full Text</Typography>
-            </UButton>
-          </a>
-        ),
+        action: <CardExpandButton />,
       }}
     >
       <Typography variant="body" pt={2}>

--- a/src/modules/Bill/components/SingleBill/CardExpandButton.tsx
+++ b/src/modules/Bill/components/SingleBill/CardExpandButton.tsx
@@ -1,0 +1,28 @@
+'use client'
+
+import { ExpandIcon } from '@/common/styles/assets/Icons'
+import { useTheme } from '@mui/material'
+import { USTWTheme } from '@/common/lib/mui/theme'
+import UIconButton from '@/common/components/atoms/UIconButton'
+
+type Props = {
+  onClick?: () => void
+}
+
+export default function CardExpandButton({ onClick }: Props) {
+  const theme = useTheme<USTWTheme>()
+  return (
+    <UIconButton
+      variant="outlined"
+      color="default"
+      sx={{
+        borderRadius: '9px',
+        border: `1.5px solid ${theme.color.grey[1400]}`,
+      }}
+      size="small"
+      onClick={onClick}
+    >
+      <ExpandIcon sx={{ color: theme.color.neutral[500] }} />
+    </UIconButton>
+  )
+}

--- a/src/modules/Bill/components/SingleBill/TitleVersion.tsx
+++ b/src/modules/Bill/components/SingleBill/TitleVersion.tsx
@@ -2,9 +2,9 @@
 
 import UButton from '@/common/components/atoms/UButton'
 import { styled } from '@/common/lib/mui/theme'
-import AccessTimeOutlinedIcon from '@mui/icons-material/AccessTimeOutlined'
 import { Bill } from '@/modules/Bill/classes/Bill'
 import Link from 'next/link'
+import { CongressIcon } from '@/common/styles/assets/Icons'
 
 const StyledTitleVersionButton = styled(UButton)(({ theme }) => ({
   backgroundColor: theme.color.common.white,
@@ -23,6 +23,7 @@ type Props = {
   bill: Bill
 }
 
+// 設計稿上是 Title Version，但 phase1 改為導向到國會網站
 export default function TitleVersion({ bill }: Props) {
   return (
     <StyledLink
@@ -32,10 +33,10 @@ export default function TitleVersion({ bill }: Props) {
     >
       <StyledTitleVersionButton
         variant="contained"
-        startIcon={<AccessTimeOutlinedIcon width={24} height={24} />}
+        startIcon={<CongressIcon width={24} height={24} />}
         rounded
       >
-        Title Version
+        Congress.gov
       </StyledTitleVersionButton>
     </StyledLink>
   )


### PR DESCRIPTION
## Summary

1. Bill 的 Title Version 改名稱及 icon
2. Bill 頁面的卡片右上角 icon 換成 Expand
3. AI Summary 用 modal 顯示完整內容

## Test Plan

https://github.com/user-attachments/assets/1f494fbc-10a8-4ae9-a5fd-4f774c35ea09

## Task

https://dev.azure.com/ustw/US%20Taiwan%20Watch/_workitems/edit/161