### PR TITLE
fix: Remove onEnter event for desktop

### DIFF
--- a/src/modules/Search/components/Desktop/DesktopSearchBar.tsx
+++ b/src/modules/Search/components/Desktop/DesktopSearchBar.tsx
@@ -77,17 +77,14 @@ const DesktopSearchBar = ({
           }
           onChange={(e) => handleSearchQueryChange(e.target.value)}
           autoFocus
-          onKeyDown={(e) => {
-            if (e.key === 'Enter') {
-              handleNavigateSearchPage(searchQuery)
-              onClose?.()
-            }
-          }}
         />
         <StyledButton
           variant="contained"
           rounded
-          onClick={() => handleNavigateSearchPage(searchQuery)}
+          onClick={() => {
+            handleNavigateSearchPage(searchQuery)
+            onClose?.()
+          }}
           disabled={!searchQuery}
         >
           {t('submit.btn.title', { ns: 'search' })}


### PR DESCRIPTION
## Summary

- No need to trigger onClose for `Enter` key event for desktop

## Test Plan

## Task