### PR TITLE
fix: I18n max depth render bug

### DIFF
--- a/.github/workflows/ustw_cms_frontend_dev.yml
+++ b/.github/workflows/ustw_cms_frontend_dev.yml
@@ -18,27 +18,22 @@ jobs:
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v2
     
-    - name: Set up environment variables
-      env:
-        NODE_ENV: development
-        NEXT_PUBLIC_WEB_BASE_URL: ${{ secrets.NEXT_PUBLIC_WEB_BASE_URL }}
-        NEXT_PUBLIC_SOUNDON_API_TOKEN: ${{ secrets.NEXT_PUBLIC_SOUNDON_API_TOKEN }}
-        NEXT_PUBLIC_SOUNDON_PODCAST_ID: ${{ secrets.NEXT_PUBLIC_SOUNDON_PODCAST_ID }}
-        NEXT_PUBLIC_GRAPHQL_API_URL: ${{ secrets.NEXT_PUBLIC_GRAPHQL_API_URL }}
-        NEXT_PUBLIC_GOOGLE_TAG_MANAGER_ID: ${{ secrets.NEXT_PUBLIC_GOOGLE_TAG_MANAGER_ID }}
-        AUTH0_DOMAIN: ${{ secrets.AUTH0_DOMAIN }}
-        AUTH0_CLIENT_ID: ${{ secrets.AUTH0_CLIENT_ID }}
-        AUTH0_CLIENT_SECRET: ${{ secrets.AUTH0_CLIENT_SECRET }}
-        AUTH0_SECRET: ${{ secrets.AUTH0_SECRET }}
-        AUTH0_M2M_CLIENT_ID: ${{ secrets.AUTH0_M2M_CLIENT_ID }}
-        AUTH0_M2M_CLIENT_SECRET: ${{ secrets.AUTH0_M2M_CLIENT_SECRET }}
-        
-    - name: Log in to ACR
-      uses: azure/docker-login@v1
-      with:
-        login-server: ${{ secrets.ACR_LOGIN_SERVER }}
-        username: ${{ secrets.ACR_USERNAME }}
-        password: ${{ secrets.ACR_PASSWORD }}
+    - name: Create .env file
+      run: |
+        echo "NODE_ENV=development" > .env
+        echo "NEXT_PUBLIC_WEB_BASE_URL=${{ secrets.NEXT_PUBLIC_WEB_BASE_URL }}" >> .env
+        echo "NEXT_PUBLIC_SOUNDON_API_TOKEN=${{ secrets.NEXT_PUBLIC_SOUNDON_API_TOKEN }}" >> .env
+        echo "NEXT_PUBLIC_SOUNDON_PODCAST_ID=${{ secrets.NEXT_PUBLIC_SOUNDON_PODCAST_ID }}" >> .env
+        echo "NEXT_PUBLIC_GRAPHQL_API_URL=${{ secrets.NEXT_PUBLIC_GRAPHQL_API_URL }}" >> .env
+        echo "NEXT_PUBLIC_GOOGLE_TAG_MANAGER_ID=${{ secrets.NEXT_PUBLIC_GOOGLE_TAG_MANAGER_ID }}" >> .env
+        echo "AUTH0_DOMAIN=${{ secrets.AUTH0_DOMAIN }}" >> .env
+        echo "AUTH0_CLIENT_ID=${{ secrets.AUTH0_CLIENT_ID }}" >> .env
+        echo "AUTH0_CLIENT_SECRET=${{ secrets.AUTH0_CLIENT_SECRET }}" >> .env
+        echo "AUTH0_SECRET=${{ secrets.AUTH0_SECRET }}" >> .env
+        echo "AUTH0_M2M_CLIENT_ID=${{ secrets.AUTH0_M2M_CLIENT_ID }}" >> .env
+        echo "AUTH0_M2M_CLIENT_SECRET=${{ secrets.AUTH0_M2M_CLIENT_SECRET }}" >> .env
+        echo "AUTH0_M2M_CLIENT_ID=${{ secrets.AUTH0_M2M_CLIENT_ID }}" >> .env
+        echo "AUTH0_M2M_CLIENT_SECRET=${{ secrets.AUTH0_M2M_CLIENT_SECRET }}" >> .env
     
     - name: Build and push Docker image
       uses: docker/build-push-action@v4

--- a/.github/workflows/ustw_cms_frontend_dev.yml
+++ b/.github/workflows/ustw_cms_frontend_dev.yml
@@ -34,6 +34,13 @@ jobs:
         echo "AUTH0_M2M_CLIENT_SECRET=${{ secrets.AUTH0_M2M_CLIENT_SECRET }}" >> .env
         echo "AUTH0_M2M_CLIENT_ID=${{ secrets.AUTH0_M2M_CLIENT_ID }}" >> .env
         echo "AUTH0_M2M_CLIENT_SECRET=${{ secrets.AUTH0_M2M_CLIENT_SECRET }}" >> .env
+
+    - name: Log in to ACR
+      uses: azure/docker-login@v1
+      with:
+        login-server: ${{ secrets.ACR_LOGIN_SERVER }}
+        username: ${{ secrets.ACR_USERNAME }}
+        password: ${{ secrets.ACR_PASSWORD }}
     
     - name: Build and push Docker image
       uses: docker/build-push-action@v4

--- a/src/common/lib/i18n/hooks/useTranslationClient.ts
+++ b/src/common/lib/i18n/hooks/useTranslationClient.ts
@@ -9,7 +9,7 @@ import LanguageDetector from 'i18next-browser-languagedetector'
 import resourcesToBackend from 'i18next-resources-to-backend'
 import { useParams } from 'next/navigation'
 import { useEffect } from 'react'
-import { useCookies } from 'react-cookie'
+import { Cookies } from 'react-cookie'
 import {
   initReactI18next,
   useTranslation,
@@ -31,9 +31,6 @@ i18next
   .init({
     ...getOptions(),
     lng: undefined, // 讓語言在 I18nProvider 中決定
-    detection: {
-      order: ['path', 'htmlTag', 'cookie', 'navigator'],
-    },
     preload: runsOnServerSide ? I18N_SUPPORTED_LANGUAGE : [],
   })
 
@@ -43,7 +40,6 @@ export default function useTranslationClient(
     lng?: Language
   }
 ) {
-  const [cookies, setCookie] = useCookies([CookiesKey.I18n])
   const ret = useTranslation(namespace, options)
 
   const { lang: paramLang } = useParams<{ lang: Language }>()
@@ -66,9 +62,10 @@ export default function useTranslationClient(
 
   // eslint-disable-next-line react-hooks/rules-of-hooks
   useEffect(() => {
-    if (cookies[CookiesKey.I18n] === lang) return
-    setCookie(CookiesKey.I18n, lang, { path: '/' })
-  }, [cookies, lang, setCookie])
+    const cookies = new Cookies()
+    if (cookies.get(CookiesKey.I18n) === lang) return
+    cookies.set(CookiesKey.I18n, lang, { path: '/' })
+  }, [lang])
 
   return ret
 }

--- a/src/common/lib/i18n/settings.ts
+++ b/src/common/lib/i18n/settings.ts
@@ -1,5 +1,6 @@
 import { InitOptions } from 'i18next'
 import { Language } from '@/common/lib/i18n/types'
+import CookiesKey from '@/common/enums/CookiesKey'
 
 export const I18N_FALLBACK_LANGUAGE: Language = 'en-US'
 export const I18N_SUPPORTED_LANGUAGE: Array<Language> = [
@@ -21,6 +22,17 @@ export function getOptions(
     lng: lang,
     fallbackNS: I18N_DEFAULT_NAMESPACE,
     defaultNS: I18N_DEFAULT_NAMESPACE,
-    ns,
+    ns /**
+     * Detection options for `i18next-browser-languagedetector`
+     * @see {@link https://github.com/i18next/i18next-browser-languageDetector}
+     * Default options
+     * @see {@link https://github.com/i18next/i18next-browser-languageDetector/blob/9efebe6ca0271c3797bc09b84babf1ba2d9b4dbb/src/index.js#L11}
+     */,
+    detection: {
+      order: ['path', 'htmlTag', 'navigator'],
+      caches: ['cookie'],
+      lookupFromPathIndex: 0,
+      lookupCookie: CookiesKey.I18n,
+    },
   }
 }

--- a/src/middlewares/withI18nMiddleware.ts
+++ b/src/middlewares/withI18nMiddleware.ts
@@ -6,21 +6,29 @@ import {
 import acceptLanguage from 'accept-language'
 import { NextRequest, NextResponse } from 'next/server'
 import { CustomNextMiddleware } from '@/middlewares/chainMiddlewares'
+import { Language } from '@/common/lib/i18n/types'
+
+const I18N_SUPPORTED_LANGUAGE_SET = new Set(I18N_SUPPORTED_LANGUAGE)
 
 acceptLanguage.languages(I18N_SUPPORTED_LANGUAGE)
 
 const getLocale = (request: NextRequest) => {
-  // 1. Get language from cookies
+  // 1. Get language from path
+  const lngFromPath = request.nextUrl.pathname.split('/')[1]
+  if (lngFromPath && I18N_SUPPORTED_LANGUAGE_SET.has(lngFromPath as Language))
+    return lngFromPath
+
+  // 2. Get language from cookies
   const lngFromCookies = request.cookies.get(CookiesKey.I18n)
   if (lngFromCookies) return lngFromCookies.value
 
-  // 2. Get language from headers
+  // 3. Get language from headers
   const lngFromHeaders = acceptLanguage.get(
     request.headers.get('Accept-Language')
   )
   if (lngFromHeaders) return lngFromHeaders
 
-  // 3. Fallback to default language
+  // 4. Fallback to default language
   return I18N_FALLBACK_LANGUAGE
 }
 


### PR DESCRIPTION
## Summary

> 兩個 tabs 開不同語言會導致兩個頁面失效

### Root cause

兩個 tabs 都會各自觸發 `useTranslationClient` 的 `useEffect`，導致兩個陷入 `Maximum update depth` 而失效。
``` tsx
  useEffect(() => {
    if (cookies[CookiesKey.I18n] === lang) return;
    setCookie(CookiesKey.I18n, lang, { path: "/" });
  }, [cookies, lang, setCookie]);
```

``` javascript
// Tab A - `/en`: `lang` 為 `en`，cookie 為 `en`， early return
// Tab B - `/ja`: `lang` 為 `ja`，cookie 為 `en`，更改 cookie 為 `ja`
// Tab A - `/en`: 聽到 cookie 變了，更改 cookie 為 `en`
// Tab B - `/ja`: 聽到 cookie 變了，更改 cookie 為 `ja`
// ...
```

將 `useCookie` hook 移除，改在 local lang (from path, see `I18nProvider`) 變化時才會觸發更改 cookie，邏輯合理：url path 變化，cookie 才會變

#### 好處
- ✅ 兩個頁面在不同語言可以正常運作

#### 壞處
- ❌ 第一個 tab 進到下一頁會變成第二個 tab 的語言

## Test Plan


## Task
