### PR TITLE
feat: Taiwan record dialog for both `create`/`update` modes

### DIFF
--- a/src/modules/People/components/PeopleTracker/TaiwanRecordSection.tsx
+++ b/src/modules/People/components/PeopleTracker/TaiwanRecordSection.tsx
@@ -10,6 +10,8 @@ import { useTheme } from '@mui/material'
 import Stack from '@mui/material/Stack'
 import { People } from '@/modules/People/business/People'
 import useTranslationClient from '@/common/lib/i18n/hooks/useTranslationClient'
+import TaiwanRecordDialog from '@/modules/TaiwanRecord/components/TaiwanRecordDialog'
+import { useState } from 'react'
 
 interface TaiwanRecordSectionProps {
   people: People
@@ -20,6 +22,7 @@ export default function TaiwanRecordSection({
 }: TaiwanRecordSectionProps) {
   const theme = useTheme<USTWTheme>()
   const { t } = useTranslationClient(['people'])
+  const [isCreateDialogOpen, setIsCreateDialogOpen] = useState(false)
 
   return (
     <LandingSectionWrapper backgroundColor={theme.color.neutral[200]}>
@@ -33,6 +36,7 @@ export default function TaiwanRecordSection({
               rounded
               size="medium"
               startIcon={<AddIcon />}
+              onClick={() => setIsCreateDialogOpen(true)}
             >
               {t('page.section.taiwanRecord.submit.btn', { ns: 'people' })}
             </UButton>
@@ -40,6 +44,11 @@ export default function TaiwanRecordSection({
         />
         <TaiwanRecordList records={people.taiwanRecords} />
       </Stack>
+      <TaiwanRecordDialog
+        mode="create"
+        open={isCreateDialogOpen}
+        onClose={() => setIsCreateDialogOpen(false)}
+      />
     </LandingSectionWrapper>
   )
 }

--- a/src/modules/TaiwanRecord/business/TaiwanRecord.ts
+++ b/src/modules/TaiwanRecord/business/TaiwanRecord.ts
@@ -5,16 +5,21 @@ import {
   TaiwanRecord as TaiwanRecordDTO,
 } from '@/common/lib/graphql/__generated__/graphql'
 
-const imagesSchema = z.array(z.string())
+export const LENGTH_CONSTRAINTS = {
+  title: 100, // 100 characters
+  content: 1000, // 1000 characters
+  images: 10, // 10 images
+  sources: 10, // 10 sources
+} as const
 
 export const taiwanRecordSchema = z.object({
   id: z.string().optional(),
-  title: z.string().optional(),
-  content: z.string().optional(),
-  images: imagesSchema.optional(),
+  title: z.string().max(LENGTH_CONSTRAINTS.title).optional(),
+  content: z.string().max(LENGTH_CONSTRAINTS.content).optional(),
+  images: z.array(z.string()).max(LENGTH_CONSTRAINTS.images).optional(),
   createdAt: z.string().datetime().optional(),
   author: z.string().optional(),
-  sources: z.array(z.string()),
+  sources: z.array(z.string()).max(LENGTH_CONSTRAINTS.sources),
   status: z.nativeEnum(TaiwanRecordStatus).optional(),
 })
 
@@ -48,7 +53,7 @@ export const taiwanRecordUpdateSchema = taiwanRecordSchema.pick({
 export type TaiwanRecordUpdateInput = z.input<typeof taiwanRecordUpdateSchema>
 export type TaiwanRecordUpdateOutput = z.infer<typeof taiwanRecordUpdateSchema>
 
-export const defaultTaiwanRecordUpdate: TaiwanRecordUpdateInput = {
+export const defaultTaiwanRecordUpdate: TaiwanRecordUpdateOutput = {
   id: '',
   title: '',
   content: '',

--- a/src/modules/TaiwanRecord/business/TaiwanRecord.ts
+++ b/src/modules/TaiwanRecord/business/TaiwanRecord.ts
@@ -5,13 +5,6 @@ import {
   TaiwanRecord as TaiwanRecordDTO,
 } from '@/common/lib/graphql/__generated__/graphql'
 
-export interface Sources {
-  links: Array<string>
-}
-const sourcesSchema = z.object({
-  from: z.string(),
-  links: z.array(z.string()),
-})
 const imagesSchema = z.array(z.string())
 
 export const taiwanRecordSchema = z.object({
@@ -21,11 +14,47 @@ export const taiwanRecordSchema = z.object({
   images: imagesSchema.optional(),
   createdAt: z.string().datetime().optional(),
   author: z.string().optional(),
-  sources: sourcesSchema.optional(),
+  sources: z.array(z.string()),
   status: z.nativeEnum(TaiwanRecordStatus).optional(),
 })
 
 export type TaiwanRecord = z.infer<typeof taiwanRecordSchema>
+
+export const taiwanRecordCreateSchema = taiwanRecordSchema.pick({
+  title: true,
+  content: true,
+  images: true,
+  sources: true,
+})
+
+export type TaiwanRecordCreateInput = z.input<typeof taiwanRecordCreateSchema>
+export type TaiwanRecordCreateOutput = z.infer<typeof taiwanRecordCreateSchema>
+
+export const defaultTaiwanRecordCreate: TaiwanRecordCreateInput = {
+  title: '',
+  content: '',
+  images: [],
+  sources: [],
+}
+
+export const taiwanRecordUpdateSchema = taiwanRecordSchema.pick({
+  id: true,
+  title: true,
+  content: true,
+  images: true,
+  sources: true,
+})
+
+export type TaiwanRecordUpdateInput = z.input<typeof taiwanRecordUpdateSchema>
+export type TaiwanRecordUpdateOutput = z.infer<typeof taiwanRecordUpdateSchema>
+
+export const defaultTaiwanRecordUpdate: TaiwanRecordUpdateInput = {
+  id: '',
+  title: '',
+  content: '',
+  images: [],
+  sources: [],
+}
 
 export class TaiwanRecordUtils {
   static parse(dto: TaiwanRecordDTO) {
@@ -37,10 +66,7 @@ export class TaiwanRecordUtils {
         dto.photos?.map((photo) => photo.photo?.url).filter(isString) ?? [],
       createdAt: dto.createdAt ?? '',
       author: dto.author?.fullName ?? '',
-      sources: {
-        from: '',
-        links: dto.sources?.map((source) => source.link).filter(isString) ?? [],
-      },
+      sources: dto.sources?.map((source) => source.link).filter(isString) ?? [],
       status: dto.status,
     })
   }

--- a/src/modules/TaiwanRecord/business/TaiwanRecord.ts
+++ b/src/modules/TaiwanRecord/business/TaiwanRecord.ts
@@ -11,14 +11,14 @@ import {
 export const MAX_IMAGE_COUNT = 10
 
 export const taiwanRecordSchema = z.object({
-  id: z.string().optional(),
-  title: z.string().optional(),
-  content: z.string().optional(),
-  images: z.array(z.string()).max(MAX_IMAGE_COUNT).optional(),
-  createdAt: z.string().datetime().optional(),
-  author: z.string().optional(),
-  sources: z.array(z.string()).optional(),
-  status: z.nativeEnum(TaiwanRecordStatus).optional(),
+  id: z.string(),
+  title: z.string().min(1),
+  content: z.string().min(1),
+  images: z.array(z.string()).max(MAX_IMAGE_COUNT),
+  createdAt: z.string().datetime(),
+  author: z.string(),
+  sources: z.array(z.string().url()),
+  status: z.nativeEnum(TaiwanRecordStatus),
 })
 
 export type TaiwanRecord = z.infer<typeof taiwanRecordSchema>

--- a/src/modules/TaiwanRecord/business/TaiwanRecord.ts
+++ b/src/modules/TaiwanRecord/business/TaiwanRecord.ts
@@ -5,21 +5,19 @@ import {
   TaiwanRecord as TaiwanRecordDTO,
 } from '@/common/lib/graphql/__generated__/graphql'
 
-export const LENGTH_CONSTRAINTS = {
-  title: 100, // 100 characters
-  content: 1000, // 1000 characters
-  images: 10, // 10 images
-  sources: 10, // 10 sources
-} as const
+/**
+ * 最多10張圖片
+ */
+export const MAX_IMAGE_COUNT = 10
 
 export const taiwanRecordSchema = z.object({
   id: z.string().optional(),
-  title: z.string().max(LENGTH_CONSTRAINTS.title).optional(),
-  content: z.string().max(LENGTH_CONSTRAINTS.content).optional(),
-  images: z.array(z.string()).max(LENGTH_CONSTRAINTS.images).optional(),
+  title: z.string().optional(),
+  content: z.string().optional(),
+  images: z.array(z.string()).max(MAX_IMAGE_COUNT).optional(),
   createdAt: z.string().datetime().optional(),
   author: z.string().optional(),
-  sources: z.array(z.string()).max(LENGTH_CONSTRAINTS.sources),
+  sources: z.array(z.string()).optional(),
   status: z.nativeEnum(TaiwanRecordStatus).optional(),
 })
 

--- a/src/modules/TaiwanRecord/components/TaiwanRecordCard.tsx
+++ b/src/modules/TaiwanRecord/components/TaiwanRecordCard.tsx
@@ -130,7 +130,7 @@ const TaiwanRecordCard = ({ taiwanRecord }: TaiwanRecordCardProps) => {
           </UHStack>
           <Stack gap={theme.spacing(0.5)}>
             <Typography variant="bodyS">{dateAndAuthor}</Typography>
-            {taiwanRecord.sources && taiwanRecord.sources.links.length > 0 && (
+            {taiwanRecord.sources && taiwanRecord.sources.length > 0 && (
               <TaiwanRecordSources sources={taiwanRecord.sources} />
             )}
           </Stack>

--- a/src/modules/TaiwanRecord/components/TaiwanRecordDialog.tsx
+++ b/src/modules/TaiwanRecord/components/TaiwanRecordDialog.tsx
@@ -1,8 +1,29 @@
 import useTranslationClient from '@/common/lib/i18n/hooks/useTranslationClient'
-import { TaiwanRecord } from '@/modules/TaiwanRecord/business/TaiwanRecord'
-import { Dialog, DialogProps, DialogTitle } from '@mui/material'
-import { useMemo } from 'react'
-import { TaiwanRecordFormMode } from '@/modules/TaiwanRecord/hooks/useTaiwanRecordForm'
+import {
+  TaiwanRecord,
+  TaiwanRecordCreateOutput,
+  TaiwanRecordUpdateOutput,
+} from '@/modules/TaiwanRecord/business/TaiwanRecord'
+import {
+  Dialog,
+  DialogProps,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Box,
+  Button,
+  TextField,
+  CircularProgress,
+  Stack,
+  Typography,
+} from '@mui/material'
+import { useMemo, useCallback, useState } from 'react'
+import useTaiwanRecordForm, {
+  TaiwanRecordFormMode,
+} from '@/modules/TaiwanRecord/hooks/useTaiwanRecordForm'
+import { Controller } from 'react-hook-form'
+import TaiwanRecordImageUpload from './TaiwanRecordImageUpload'
+import TaiwanRecordSourceManager from './TaiwanRecordSourceManager'
 
 type TaiwanRecordDialogProps = DialogProps & {
   mode: TaiwanRecordFormMode
@@ -10,10 +31,14 @@ type TaiwanRecordDialogProps = DialogProps & {
 }
 
 export default function TaiwanRecordDialog(props: TaiwanRecordDialogProps) {
-  const { mode, ...dialogProps } = props
-  const { t } = useTranslationClient(['taiwan_record'])
+  const { mode, record, ...dialogProps } = props
+  const { t } = useTranslationClient(['taiwan_record', 'common'])
+  const [isSubmitting, setIsSubmitting] = useState(false)
 
-  // const { form, handleReset, handleSubmit } = useTaiwanRecordForm({ mode })
+  const { form, handleReset, handleSubmit } = useTaiwanRecordForm({
+    mode,
+    record,
+  })
 
   const title = useMemo(() => {
     return mode === 'create'
@@ -21,9 +46,141 @@ export default function TaiwanRecordDialog(props: TaiwanRecordDialogProps) {
       : t('dialog.update.title', { ns: 'taiwan_record' })
   }, [mode, t])
 
+  const onSubmit = useCallback(
+    async (data: TaiwanRecordCreateOutput | TaiwanRecordUpdateOutput) => {
+      setIsSubmitting(true)
+      try {
+        await handleSubmit(data)
+      } finally {
+        setIsSubmitting(false)
+      }
+    },
+    [handleSubmit]
+  )
+
+  const onClose = useCallback(() => {
+    if (!isSubmitting) {
+      handleReset()
+      dialogProps.onClose?.({}, 'backdropClick')
+    }
+  }, [isSubmitting, handleReset, dialogProps])
+
   return (
-    <Dialog {...dialogProps}>
+    <Dialog
+      {...dialogProps}
+      onClose={(_e, reason) => {
+        // Prevent closing the dialog when clicking outside
+        if (reason === 'backdropClick') return
+        onClose()
+      }}
+      maxWidth="sm"
+      fullWidth
+    >
       <DialogTitle>{title}</DialogTitle>
+      <DialogContent>
+        <Box
+          component="form"
+          sx={{ pt: 2 }}
+          onSubmit={form.handleSubmit(onSubmit)}
+        >
+          <Stack gap={2}>
+            {/* 標題欄位 */}
+            <Controller
+              control={form.control}
+              name="title"
+              rules={{
+                required: t('form.required', { ns: 'common' }),
+              }}
+              render={({ field, fieldState: { error } }) => (
+                <Box>
+                  <Typography variant="body2" fontWeight={600} mb={1}>
+                    {t('form.title.label', { ns: 'taiwan_record' })}
+                  </Typography>
+                  <TextField
+                    {...field}
+                    fullWidth
+                    size="small"
+                    error={!!error}
+                    helperText={error?.message}
+                    placeholder={t('form.title.placeholder', {
+                      ns: 'taiwan_record',
+                    })}
+                    disabled={isSubmitting}
+                    color="info"
+                  />
+                </Box>
+              )}
+            />
+
+            {/* 內文欄位 */}
+            <Controller
+              control={form.control}
+              name="content"
+              rules={{
+                required: t('form.required', { ns: 'common' }),
+              }}
+              render={({ field, fieldState: { error } }) => (
+                <Box>
+                  <Typography variant="body2" fontWeight={600} mb={1}>
+                    {t('form.content.label', { ns: 'taiwan_record' })}
+                  </Typography>
+                  <TextField
+                    {...field}
+                    fullWidth
+                    multiline
+                    rows={5}
+                    error={!!error}
+                    helperText={error?.message}
+                    placeholder={t('form.content.placeholder', {
+                      ns: 'taiwan_record',
+                    })}
+                    disabled={isSubmitting}
+                    color="info"
+                  />
+                </Box>
+              )}
+            />
+
+            {/* 圖片上傳元件 */}
+            <TaiwanRecordImageUpload
+              control={form.control}
+              fieldName="images"
+            />
+
+            {/* 連結管理元件 */}
+            <TaiwanRecordSourceManager
+              control={form.control}
+              fieldName="sources"
+            />
+          </Stack>
+        </Box>
+      </DialogContent>
+      <DialogActions sx={{ p: 2 }}>
+        <Button
+          onClick={onClose}
+          disabled={isSubmitting}
+          sx={{ textTransform: 'none' }}
+          color="info"
+        >
+          {t('cancel.btn', { ns: 'common' })}
+        </Button>
+        <Button
+          onClick={form.handleSubmit(onSubmit)}
+          variant="contained"
+          color="info"
+          disabled={isSubmitting}
+          sx={{ textTransform: 'none' }}
+        >
+          {isSubmitting && (
+            <CircularProgress size={16} sx={{ mr: 1 }} color="inherit" />
+          )}
+          {isSubmitting
+            ? t('dialog.submitting.msg', { ns: 'taiwan_record' })
+            : mode === 'create'
+              ? t('dialog.create.btn', { ns: 'taiwan_record' })
+              : t('dialog.update.btn', { ns: 'taiwan_record' })}
+        </Button>
+      </DialogActions>
     </Dialog>
   )
 }

--- a/src/modules/TaiwanRecord/components/TaiwanRecordDialog.tsx
+++ b/src/modules/TaiwanRecord/components/TaiwanRecordDialog.tsx
@@ -9,7 +9,6 @@ import {
   DialogProps,
   DialogTitle,
   DialogContent,
-  DialogActions,
   Box,
   Button,
   TextField,
@@ -75,6 +74,13 @@ export default function TaiwanRecordDialog(props: TaiwanRecordDialogProps) {
       }}
       maxWidth="sm"
       fullWidth
+      PaperProps={{
+        sx: {
+          overflowX: 'hidden',
+          overflowY: 'auto',
+          maxHeight: '80dvh',
+        },
+      }}
     >
       <DialogTitle>{title}</DialogTitle>
       <DialogContent>
@@ -148,35 +154,43 @@ export default function TaiwanRecordDialog(props: TaiwanRecordDialogProps) {
               {/* 連結管理元件 */}
               <TaiwanRecordSourceManager />
             </Stack>
+
+            <Box
+              sx={{
+                display: 'flex',
+                justifyContent: 'flex-end',
+                gap: 1,
+                mt: 2,
+              }}
+            >
+              <Button
+                onClick={onClose}
+                disabled={isSubmitting}
+                sx={{ textTransform: 'none' }}
+                color="info"
+              >
+                {t('cancel.btn', { ns: 'common' })}
+              </Button>
+              <Button
+                type="submit"
+                variant="contained"
+                color="info"
+                disabled={isSubmitting}
+                sx={{ textTransform: 'none' }}
+              >
+                {isSubmitting && (
+                  <CircularProgress size={16} sx={{ mr: 1 }} color="inherit" />
+                )}
+                {isSubmitting
+                  ? t('dialog.submitting.msg', { ns: 'taiwan_record' })
+                  : mode === 'create'
+                    ? t('dialog.create.btn', { ns: 'taiwan_record' })
+                    : t('dialog.update.btn', { ns: 'taiwan_record' })}
+              </Button>
+            </Box>
           </Box>
         </FormProvider>
       </DialogContent>
-      <DialogActions sx={{ p: 2 }}>
-        <Button
-          onClick={onClose}
-          disabled={isSubmitting}
-          sx={{ textTransform: 'none' }}
-          color="info"
-        >
-          {t('cancel.btn', { ns: 'common' })}
-        </Button>
-        <Button
-          onClick={form.handleSubmit(onSubmit)}
-          variant="contained"
-          color="info"
-          disabled={isSubmitting}
-          sx={{ textTransform: 'none' }}
-        >
-          {isSubmitting && (
-            <CircularProgress size={16} sx={{ mr: 1 }} color="inherit" />
-          )}
-          {isSubmitting
-            ? t('dialog.submitting.msg', { ns: 'taiwan_record' })
-            : mode === 'create'
-              ? t('dialog.create.btn', { ns: 'taiwan_record' })
-              : t('dialog.update.btn', { ns: 'taiwan_record' })}
-        </Button>
-      </DialogActions>
     </Dialog>
   )
 }

--- a/src/modules/TaiwanRecord/components/TaiwanRecordDialog.tsx
+++ b/src/modules/TaiwanRecord/components/TaiwanRecordDialog.tsx
@@ -21,9 +21,9 @@ import { useMemo, useCallback, useState } from 'react'
 import useTaiwanRecordForm, {
   TaiwanRecordFormMode,
 } from '@/modules/TaiwanRecord/hooks/useTaiwanRecordForm'
-import { Controller } from 'react-hook-form'
-import TaiwanRecordImageUpload from './TaiwanRecordImageUpload'
-import TaiwanRecordSourceManager from './TaiwanRecordSourceManager'
+import { Controller, FormProvider } from 'react-hook-form'
+import TaiwanRecordImageUpload from '@/modules/TaiwanRecord/components/TaiwanRecordImageUpload'
+import TaiwanRecordSourceManager from '@/modules/TaiwanRecord/components/TaiwanRecordSourceManager'
 
 type TaiwanRecordDialogProps = DialogProps & {
   mode: TaiwanRecordFormMode
@@ -78,82 +78,78 @@ export default function TaiwanRecordDialog(props: TaiwanRecordDialogProps) {
     >
       <DialogTitle>{title}</DialogTitle>
       <DialogContent>
-        <Box
-          component="form"
-          sx={{ pt: 2 }}
-          onSubmit={form.handleSubmit(onSubmit)}
-        >
-          <Stack gap={2}>
-            {/* 標題欄位 */}
-            <Controller
-              control={form.control}
-              name="title"
-              rules={{
-                required: t('form.required', { ns: 'common' }),
-              }}
-              render={({ field, fieldState: { error } }) => (
-                <Box>
-                  <Typography variant="body2" fontWeight={600} mb={1}>
-                    {t('form.title.label', { ns: 'taiwan_record' })}
-                  </Typography>
-                  <TextField
-                    {...field}
-                    fullWidth
-                    size="small"
-                    error={!!error}
-                    helperText={error?.message}
-                    placeholder={t('form.title.placeholder', {
-                      ns: 'taiwan_record',
-                    })}
-                    disabled={isSubmitting}
-                    color="info"
-                  />
-                </Box>
-              )}
-            />
+        <FormProvider {...form}>
+          <Box
+            component="form"
+            sx={{ pt: 2 }}
+            onSubmit={form.handleSubmit(onSubmit)}
+          >
+            <Stack gap={2}>
+              {/* 標題欄位 */}
+              <Controller
+                control={form.control}
+                name="title"
+                rules={{
+                  required: t('form.required', { ns: 'common' }),
+                }}
+                render={({ field, fieldState: { error } }) => (
+                  <Box>
+                    <Typography variant="body2" fontWeight={600} mb={1}>
+                      {t('form.title.label', { ns: 'taiwan_record' })}
+                    </Typography>
+                    <TextField
+                      {...field}
+                      fullWidth
+                      size="small"
+                      error={!!error}
+                      helperText={error?.message}
+                      placeholder={t('form.title.placeholder', {
+                        ns: 'taiwan_record',
+                      })}
+                      disabled={isSubmitting}
+                      color="info"
+                    />
+                  </Box>
+                )}
+              />
 
-            {/* 內文欄位 */}
-            <Controller
-              control={form.control}
-              name="content"
-              rules={{
-                required: t('form.required', { ns: 'common' }),
-              }}
-              render={({ field, fieldState: { error } }) => (
-                <Box>
-                  <Typography variant="body2" fontWeight={600} mb={1}>
-                    {t('form.content.label', { ns: 'taiwan_record' })}
-                  </Typography>
-                  <TextField
-                    {...field}
-                    fullWidth
-                    multiline
-                    rows={5}
-                    error={!!error}
-                    helperText={error?.message}
-                    placeholder={t('form.content.placeholder', {
-                      ns: 'taiwan_record',
-                    })}
-                    disabled={isSubmitting}
-                    color="info"
-                  />
-                </Box>
-              )}
-            />
+              {/* 內文欄位 */}
+              <Controller
+                control={form.control}
+                name="content"
+                rules={{
+                  required: t('form.required', { ns: 'common' }),
+                }}
+                render={({ field, fieldState: { error } }) => (
+                  <Box>
+                    <Typography variant="body2" fontWeight={600} mb={1}>
+                      {t('form.content.label', { ns: 'taiwan_record' })}
+                    </Typography>
+                    <TextField
+                      {...field}
+                      fullWidth
+                      multiline
+                      rows={5}
+                      error={!!error}
+                      helperText={error?.message}
+                      placeholder={t('form.content.placeholder', {
+                        ns: 'taiwan_record',
+                      })}
+                      disabled={isSubmitting}
+                      color="info"
+                    />
+                  </Box>
+                )}
+              />
 
-            {/* 圖片上傳元件 */}
-            <TaiwanRecordImageUpload
-              control={form.control}
-              fieldName="images"
-            />
+              {/* 圖片上傳元件 */}
+              <TaiwanRecordImageUpload />
 
-            {/* 連結管理元件 */}
-            <TaiwanRecordSourceManager
-              control={form.control}
-              fieldName="sources"
-            />
-          </Stack>
-        </Box>
+              {/* 連結管理元件 */}
+              <TaiwanRecordSourceManager />
+            </Stack>
+          </Box>
+        </FormProvider>
       </DialogContent>
       <DialogActions sx={{ p: 2 }}>
         <Button

--- a/src/modules/TaiwanRecord/components/TaiwanRecordDialog.tsx
+++ b/src/modules/TaiwanRecord/components/TaiwanRecordDialog.tsx
@@ -13,6 +13,8 @@ export default function TaiwanRecordDialog(props: TaiwanRecordDialogProps) {
   const { mode, ...dialogProps } = props
   const { t } = useTranslationClient(['taiwan_record'])
 
+  // const { form, handleReset, handleSubmit } = useTaiwanRecordForm({ mode })
+
   const title = useMemo(() => {
     return mode === 'create'
       ? t('dialog.create.title', { ns: 'taiwan_record' })

--- a/src/modules/TaiwanRecord/components/TaiwanRecordDialog.tsx
+++ b/src/modules/TaiwanRecord/components/TaiwanRecordDialog.tsx
@@ -1,0 +1,27 @@
+import useTranslationClient from '@/common/lib/i18n/hooks/useTranslationClient'
+import { TaiwanRecord } from '@/modules/TaiwanRecord/business/TaiwanRecord'
+import { Dialog, DialogProps, DialogTitle } from '@mui/material'
+import { useMemo } from 'react'
+import { TaiwanRecordFormMode } from '@/modules/TaiwanRecord/hooks/useTaiwanRecordForm'
+
+type TaiwanRecordDialogProps = DialogProps & {
+  mode: TaiwanRecordFormMode
+  record?: TaiwanRecord
+}
+
+export default function TaiwanRecordDialog(props: TaiwanRecordDialogProps) {
+  const { mode, ...dialogProps } = props
+  const { t } = useTranslationClient(['taiwan_record'])
+
+  const title = useMemo(() => {
+    return mode === 'create'
+      ? t('dialog.create.title', { ns: 'taiwan_record' })
+      : t('dialog.update.title', { ns: 'taiwan_record' })
+  }, [mode, t])
+
+  return (
+    <Dialog {...dialogProps}>
+      <DialogTitle>{title}</DialogTitle>
+    </Dialog>
+  )
+}

--- a/src/modules/TaiwanRecord/components/TaiwanRecordImageUpload.tsx
+++ b/src/modules/TaiwanRecord/components/TaiwanRecordImageUpload.tsx
@@ -1,68 +1,69 @@
-import { memo, useCallback } from 'react'
-import { Controller, FieldPath, Control } from 'react-hook-form'
+import { memo, useCallback, useMemo } from 'react'
+import { Controller, useFormContext, useWatch } from 'react-hook-form'
 import { Box, Button, IconButton, Stack, Typography } from '@mui/material'
 import CloudUploadIcon from '@mui/icons-material/CloudUpload'
 import DeleteIcon from '@mui/icons-material/Delete'
 import {
   TaiwanRecordCreateInput,
   TaiwanRecordUpdateInput,
-  LENGTH_CONSTRAINTS,
+  MAX_IMAGE_COUNT,
 } from '@/modules/TaiwanRecord/business/TaiwanRecord'
 import useTranslationClient from '@/common/lib/i18n/hooks/useTranslationClient'
 
-interface TaiwanRecordImageUploadProps {
-  control: Control<TaiwanRecordCreateInput | TaiwanRecordUpdateInput>
-  fieldName: FieldPath<TaiwanRecordCreateInput | TaiwanRecordUpdateInput>
-}
-
-const TaiwanRecordImageUpload = memo(function TaiwanRecordImageUpload(
-  props: TaiwanRecordImageUploadProps
-) {
-  const { control, fieldName } = props
+const TaiwanRecordImageUpload = memo(function TaiwanRecordImageUpload() {
+  const { control } = useFormContext<
+    TaiwanRecordCreateInput | TaiwanRecordUpdateInput
+  >()
   const { t } = useTranslationClient(['taiwan_record'])
+  const images = useWatch({ control, name: 'images' })
 
-  const handleFileChange = useCallback(
-    (currentImages: string[], files: FileList | null) => {
-      if (!files) return currentImages
+  const handleAddImages = useCallback(
+    (files: FileList | null): Promise<string[]> => {
+      return new Promise((resolve) => {
+        if (!files) return resolve([])
 
-      const newImages: string[] = []
-      for (let i = 0; i < files.length; i++) {
-        const file = files[i]
-        if (file.type.startsWith('image/')) {
-          const reader = new FileReader()
-          reader.onload = (e) => {
-            if (e.target?.result) {
-              newImages.push(e.target.result as string)
+        const newImages: string[] = []
+        for (let i = 0; i < files.length; i++) {
+          const file = files[i]
+          if (file.type.startsWith('image/')) {
+            const reader = new FileReader()
+            reader.onload = (e) => {
+              if (e.target?.result) {
+                newImages.push(e.target.result as string)
+                if (i === files.length - 1) {
+                  resolve(newImages)
+                }
+              }
             }
+            reader.readAsDataURL(file)
           }
-          reader.readAsDataURL(file)
         }
-      }
-
-      return [...currentImages, ...newImages]
+      })
     },
     []
   )
 
-  const handleRemoveImage = useCallback(
+  const getRemovedFilteredImages = useCallback(
     (currentImages: string[], index: number) => {
       return currentImages.filter((_, i) => i !== index)
     },
     []
   )
 
-  const maxImages = LENGTH_CONSTRAINTS.images
-  const canAddMore = (images: string[]) => images.length < maxImages
+  const canAddMore = useMemo(
+    () => images && images.length < MAX_IMAGE_COUNT,
+    [images]
+  )
 
   return (
     <Controller
       control={control}
-      name={fieldName}
+      name="images"
       render={({ field }) => (
         <Box>
           <Typography variant="body2" fontWeight={600} mb={1}>
             {t('form.images.label', { ns: 'taiwan_record' })}
-            {!canAddMore(field.value as string[]) && (
+            {!canAddMore && (
               <Typography
                 component="span"
                 variant="caption"
@@ -70,7 +71,7 @@ const TaiwanRecordImageUpload = memo(function TaiwanRecordImageUpload(
               >
                 (
                 {t('form.images.maxReached', {
-                  max: maxImages,
+                  max: MAX_IMAGE_COUNT,
                   ns: 'taiwan_record',
                 })}
                 )
@@ -85,13 +86,16 @@ const TaiwanRecordImageUpload = memo(function TaiwanRecordImageUpload(
                 type="file"
                 multiple
                 accept="image/*"
-                onChange={(e) => {
-                  const images = handleFileChange(
-                    (field.value as string[]) || [],
-                    e.target.files
-                  )
+                onChange={async (e) => {
+                  const uploadedImages = await handleAddImages(e.target.files)
+                  const comprehensiveUploadedImages = [
+                    ...(field.value || []),
+                    ...uploadedImages,
+                  ]
                   // 限制最多張數
-                  field.onChange(images.slice(0, maxImages))
+                  field.onChange(
+                    comprehensiveUploadedImages.slice(0, MAX_IMAGE_COUNT)
+                  )
                 }}
                 style={{ display: 'none' }}
                 id="image-upload-input"
@@ -101,7 +105,7 @@ const TaiwanRecordImageUpload = memo(function TaiwanRecordImageUpload(
                   component="span"
                   variant="outlined"
                   startIcon={<CloudUploadIcon />}
-                  disabled={!canAddMore((field.value as string[]) || [])}
+                  disabled={!canAddMore}
                   fullWidth
                   sx={{ textTransform: 'none' }}
                   color="info"
@@ -112,12 +116,12 @@ const TaiwanRecordImageUpload = memo(function TaiwanRecordImageUpload(
             </Box>
 
             {/* 已上傳的圖片列表 */}
-            {(field.value as string[])?.length > 0 && (
+            {field.value && field.value.length > 0 && (
               <Stack gap={1}>
                 <Typography variant="caption" sx={{ color: 'text.secondary' }}>
                   {t('form.images.count', {
-                    current: (field.value as string[]).length,
-                    max: maxImages,
+                    current: field.value.length || 0,
+                    max: MAX_IMAGE_COUNT,
                     ns: 'taiwan_record',
                   })}
                 </Typography>
@@ -128,7 +132,7 @@ const TaiwanRecordImageUpload = memo(function TaiwanRecordImageUpload(
                     gap: 1,
                   }}
                 >
-                  {(field.value as string[]).map((image, index) => (
+                  {field.value.map((image, index) => (
                     <Box
                       key={index}
                       sx={{
@@ -155,8 +159,9 @@ const TaiwanRecordImageUpload = memo(function TaiwanRecordImageUpload(
                       <IconButton
                         size="small"
                         onClick={() => {
+                          if (!field.value) return
                           field.onChange(
-                            handleRemoveImage(field.value as string[], index)
+                            getRemovedFilteredImages(field.value, index)
                           )
                         }}
                         sx={{

--- a/src/modules/TaiwanRecord/components/TaiwanRecordImageUpload.tsx
+++ b/src/modules/TaiwanRecord/components/TaiwanRecordImageUpload.tsx
@@ -1,0 +1,186 @@
+import { memo, useCallback } from 'react'
+import { Controller, FieldPath, Control } from 'react-hook-form'
+import { Box, Button, IconButton, Stack, Typography } from '@mui/material'
+import CloudUploadIcon from '@mui/icons-material/CloudUpload'
+import DeleteIcon from '@mui/icons-material/Delete'
+import {
+  TaiwanRecordCreateInput,
+  TaiwanRecordUpdateInput,
+  LENGTH_CONSTRAINTS,
+} from '@/modules/TaiwanRecord/business/TaiwanRecord'
+import useTranslationClient from '@/common/lib/i18n/hooks/useTranslationClient'
+
+interface TaiwanRecordImageUploadProps {
+  control: Control<TaiwanRecordCreateInput | TaiwanRecordUpdateInput>
+  fieldName: FieldPath<TaiwanRecordCreateInput | TaiwanRecordUpdateInput>
+}
+
+const TaiwanRecordImageUpload = memo(function TaiwanRecordImageUpload(
+  props: TaiwanRecordImageUploadProps
+) {
+  const { control, fieldName } = props
+  const { t } = useTranslationClient(['taiwan_record'])
+
+  const handleFileChange = useCallback(
+    (currentImages: string[], files: FileList | null) => {
+      if (!files) return currentImages
+
+      const newImages: string[] = []
+      for (let i = 0; i < files.length; i++) {
+        const file = files[i]
+        if (file.type.startsWith('image/')) {
+          const reader = new FileReader()
+          reader.onload = (e) => {
+            if (e.target?.result) {
+              newImages.push(e.target.result as string)
+            }
+          }
+          reader.readAsDataURL(file)
+        }
+      }
+
+      return [...currentImages, ...newImages]
+    },
+    []
+  )
+
+  const handleRemoveImage = useCallback(
+    (currentImages: string[], index: number) => {
+      return currentImages.filter((_, i) => i !== index)
+    },
+    []
+  )
+
+  const maxImages = LENGTH_CONSTRAINTS.images
+  const canAddMore = (images: string[]) => images.length < maxImages
+
+  return (
+    <Controller
+      control={control}
+      name={fieldName}
+      render={({ field }) => (
+        <Box>
+          <Typography variant="body2" fontWeight={600} mb={1}>
+            {t('form.images.label', { ns: 'taiwan_record' })}
+            {!canAddMore(field.value as string[]) && (
+              <Typography
+                component="span"
+                variant="caption"
+                sx={{ ml: 1, color: 'text.secondary' }}
+              >
+                (
+                {t('form.images.maxReached', {
+                  max: maxImages,
+                  ns: 'taiwan_record',
+                })}
+                )
+              </Typography>
+            )}
+          </Typography>
+
+          <Stack gap={2}>
+            {/* 上傳按鈕 */}
+            <Box>
+              <input
+                type="file"
+                multiple
+                accept="image/*"
+                onChange={(e) => {
+                  const images = handleFileChange(
+                    (field.value as string[]) || [],
+                    e.target.files
+                  )
+                  // 限制最多張數
+                  field.onChange(images.slice(0, maxImages))
+                }}
+                style={{ display: 'none' }}
+                id="image-upload-input"
+              />
+              <label htmlFor="image-upload-input" style={{ width: '100%' }}>
+                <Button
+                  component="span"
+                  variant="outlined"
+                  startIcon={<CloudUploadIcon />}
+                  disabled={!canAddMore((field.value as string[]) || [])}
+                  fullWidth
+                  sx={{ textTransform: 'none' }}
+                  color="info"
+                >
+                  {t('form.images.upload.btn', { ns: 'taiwan_record' })}
+                </Button>
+              </label>
+            </Box>
+
+            {/* 已上傳的圖片列表 */}
+            {(field.value as string[])?.length > 0 && (
+              <Stack gap={1}>
+                <Typography variant="caption" sx={{ color: 'text.secondary' }}>
+                  {t('form.images.count', {
+                    current: (field.value as string[]).length,
+                    max: maxImages,
+                    ns: 'taiwan_record',
+                  })}
+                </Typography>
+                <Box
+                  sx={{
+                    display: 'grid',
+                    gridTemplateColumns: 'repeat(auto-fill, minmax(80px, 1fr))',
+                    gap: 1,
+                  }}
+                >
+                  {(field.value as string[]).map((image, index) => (
+                    <Box
+                      key={index}
+                      sx={{
+                        position: 'relative',
+                        aspectRatio: '1',
+                        borderRadius: 1,
+                        overflow: 'hidden',
+                        backgroundColor: '#f5f5f5',
+                        border: '1px solid #e0e0e0',
+                        display: 'flex',
+                        alignItems: 'center',
+                        justifyContent: 'center',
+                      }}
+                    >
+                      <img
+                        src={image}
+                        alt={`uploaded-${index}`}
+                        style={{
+                          width: '100%',
+                          height: '100%',
+                          objectFit: 'cover',
+                        }}
+                      />
+                      <IconButton
+                        size="small"
+                        onClick={() => {
+                          field.onChange(
+                            handleRemoveImage(field.value as string[], index)
+                          )
+                        }}
+                        sx={{
+                          position: 'absolute',
+                          top: -8,
+                          right: -8,
+                          backgroundColor: 'rgba(0, 0, 0, 0.6)',
+                          '&:hover': {
+                            backgroundColor: 'rgba(0, 0, 0, 0.8)',
+                          },
+                        }}
+                      >
+                        <DeleteIcon sx={{ color: 'white', fontSize: '1rem' }} />
+                      </IconButton>
+                    </Box>
+                  ))}
+                </Box>
+              </Stack>
+            )}
+          </Stack>
+        </Box>
+      )}
+    />
+  )
+})
+
+export default TaiwanRecordImageUpload

--- a/src/modules/TaiwanRecord/components/TaiwanRecordImageUpload.tsx
+++ b/src/modules/TaiwanRecord/components/TaiwanRecordImageUpload.tsx
@@ -1,14 +1,87 @@
-import { memo, useCallback, useMemo } from 'react'
+import { memo, useCallback, useMemo, useState } from 'react'
 import { Controller, useFormContext, useWatch } from 'react-hook-form'
-import { Box, Button, IconButton, Stack, Typography } from '@mui/material'
+import { Box, Button, Stack, Typography } from '@mui/material'
 import CloudUploadIcon from '@mui/icons-material/CloudUpload'
-import DeleteIcon from '@mui/icons-material/Delete'
+import ClearIcon from '@mui/icons-material/Clear'
 import {
   TaiwanRecordCreateInput,
   TaiwanRecordUpdateInput,
   MAX_IMAGE_COUNT,
 } from '@/modules/TaiwanRecord/business/TaiwanRecord'
 import useTranslationClient from '@/common/lib/i18n/hooks/useTranslationClient'
+import UIconButton from '@/common/components/atoms/UIconButton'
+import { useTheme } from '@mui/material/styles'
+import { USTWTheme } from '@/common/lib/mui/theme'
+
+type PriviewImageProps = {
+  image: string
+  index: number
+  onRemove: () => void
+}
+
+const PriviewImage = memo(function PriviewImage({
+  image,
+  index,
+  onRemove,
+}: PriviewImageProps) {
+  const theme = useTheme<USTWTheme>()
+  const [showRemoveButton, setShowRemoveButton] = useState(false)
+
+  return (
+    <Box
+      sx={{
+        position: 'relative',
+        aspectRatio: '1',
+        borderRadius: 1,
+        overflow: 'visible',
+        backgroundColor: '#f5f5f5',
+        border: '1px solid #e0e0e0',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+      }}
+      onMouseEnter={() => setShowRemoveButton(true)}
+      onMouseLeave={() => setShowRemoveButton(false)}
+    >
+      <img
+        src={image}
+        alt={`uploaded-${index}`}
+        style={{
+          width: '100%',
+          height: '100%',
+          objectFit: 'cover',
+        }}
+      />
+      {showRemoveButton && (
+        <Box
+          sx={{
+            position: 'absolute',
+            opacity: 0.8,
+            width: '100%',
+            height: '100%',
+            backgroundColor: theme.color.grey[2300],
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+          }}
+        >
+          <UIconButton
+            size="xs"
+            variant="rounded"
+            color="white"
+            onClick={onRemove}
+            sx={{
+              p: 0.5,
+              backgroundColor: theme.color.grey[1100],
+            }}
+          >
+            <ClearIcon sx={{ width: 12, height: 12 }} />
+          </UIconButton>
+        </Box>
+      )}
+    </Box>
+  )
+})
 
 const TaiwanRecordImageUpload = memo(function TaiwanRecordImageUpload() {
   const { control } = useFormContext<
@@ -17,31 +90,27 @@ const TaiwanRecordImageUpload = memo(function TaiwanRecordImageUpload() {
   const { t } = useTranslationClient(['taiwan_record'])
   const images = useWatch({ control, name: 'images' })
 
-  const handleAddImages = useCallback(
-    (files: FileList | null): Promise<string[]> => {
-      return new Promise((resolve) => {
-        if (!files) return resolve([])
+  const handleAddImages = useCallback((files: FileList | null) => {
+    if (!files) return Promise.resolve([])
 
-        const newImages: string[] = []
-        for (let i = 0; i < files.length; i++) {
-          const file = files[i]
-          if (file.type.startsWith('image/')) {
-            const reader = new FileReader()
-            reader.onload = (e) => {
-              if (e.target?.result) {
-                newImages.push(e.target.result as string)
-                if (i === files.length - 1) {
-                  resolve(newImages)
-                }
-              }
+    const imagePromises = Array.from(files)
+      .filter((file) => file.type.startsWith('image/'))
+      .map((file) => {
+        return new Promise<string>((resolve, reject) => {
+          const reader = new FileReader()
+          reader.onload = (e) => {
+            if (e.target?.result) {
+              resolve(e.target.result as string)
             }
-            reader.readAsDataURL(file)
           }
-        }
+          reader.onerror = () =>
+            reject(new Error(`Failed to read ${file.name}`))
+          reader.readAsDataURL(file)
+        })
       })
-    },
-    []
-  )
+
+    return Promise.allSettled(imagePromises)
+  }, [])
 
   const getRemovedFilteredImages = useCallback(
     (currentImages: string[], index: number) => {
@@ -90,7 +159,9 @@ const TaiwanRecordImageUpload = memo(function TaiwanRecordImageUpload() {
                   const uploadedImages = await handleAddImages(e.target.files)
                   const comprehensiveUploadedImages = [
                     ...(field.value || []),
-                    ...uploadedImages,
+                    ...uploadedImages
+                      .filter((image) => image.status === 'fulfilled')
+                      .map((image) => image.value),
                   ]
                   // 限制最多張數
                   field.onChange(
@@ -133,50 +204,17 @@ const TaiwanRecordImageUpload = memo(function TaiwanRecordImageUpload() {
                   }}
                 >
                   {field.value.map((image, index) => (
-                    <Box
+                    <PriviewImage
                       key={index}
-                      sx={{
-                        position: 'relative',
-                        aspectRatio: '1',
-                        borderRadius: 1,
-                        overflow: 'hidden',
-                        backgroundColor: '#f5f5f5',
-                        border: '1px solid #e0e0e0',
-                        display: 'flex',
-                        alignItems: 'center',
-                        justifyContent: 'center',
+                      image={image}
+                      index={index}
+                      onRemove={() => {
+                        if (!field.value) return
+                        field.onChange(
+                          getRemovedFilteredImages(field.value, index)
+                        )
                       }}
-                    >
-                      <img
-                        src={image}
-                        alt={`uploaded-${index}`}
-                        style={{
-                          width: '100%',
-                          height: '100%',
-                          objectFit: 'cover',
-                        }}
-                      />
-                      <IconButton
-                        size="small"
-                        onClick={() => {
-                          if (!field.value) return
-                          field.onChange(
-                            getRemovedFilteredImages(field.value, index)
-                          )
-                        }}
-                        sx={{
-                          position: 'absolute',
-                          top: -8,
-                          right: -8,
-                          backgroundColor: 'rgba(0, 0, 0, 0.6)',
-                          '&:hover': {
-                            backgroundColor: 'rgba(0, 0, 0, 0.8)',
-                          },
-                        }}
-                      >
-                        <DeleteIcon sx={{ color: 'white', fontSize: '1rem' }} />
-                      </IconButton>
-                    </Box>
+                    />
                   ))}
                 </Box>
               </Stack>

--- a/src/modules/TaiwanRecord/components/TaiwanRecordSourceManager.tsx
+++ b/src/modules/TaiwanRecord/components/TaiwanRecordSourceManager.tsx
@@ -1,65 +1,46 @@
 import { memo, useCallback, useState } from 'react'
-import { Controller, FieldPath, Control } from 'react-hook-form'
+import { Controller, useFormContext, useWatch } from 'react-hook-form'
 import { Box, Button, Chip, Stack, TextField, Typography } from '@mui/material'
 import AddIcon from '@mui/icons-material/Add'
 import LinkIcon from '@mui/icons-material/Link'
 import {
   TaiwanRecordCreateInput,
   TaiwanRecordUpdateInput,
-  LENGTH_CONSTRAINTS,
 } from '@/modules/TaiwanRecord/business/TaiwanRecord'
 import useTranslationClient from '@/common/lib/i18n/hooks/useTranslationClient'
 import { z } from 'zod'
 
-interface TaiwanRecordSourceManagerProps {
-  control: Control<TaiwanRecordCreateInput | TaiwanRecordUpdateInput>
-  fieldName: FieldPath<TaiwanRecordCreateInput | TaiwanRecordUpdateInput>
-}
-
-const TaiwanRecordSourceManager = memo(function TaiwanRecordSourceManager(
-  props: TaiwanRecordSourceManagerProps
-) {
-  const { control, fieldName } = props
+const TaiwanRecordSourceManager = memo(function TaiwanRecordSourceManager() {
+  const { control } = useFormContext<
+    TaiwanRecordCreateInput | TaiwanRecordUpdateInput
+  >()
   const { t } = useTranslationClient(['taiwan_record'])
   const [inputUrl, setInputUrl] = useState('')
   const [urlError, setUrlError] = useState('')
 
-  const maxSources = LENGTH_CONSTRAINTS.sources
+  const sources = useWatch({ control, name: 'sources' })
 
-  const handleAddSource = useCallback(
-    (currentSources: string[]) => {
-      setUrlError('')
+  const handleAddSource = useCallback(() => {
+    setUrlError('')
 
-      if (!inputUrl.trim()) {
-        setUrlError(t('form.sources.error.empty', { ns: 'taiwan_record' }))
-        return
-      }
+    if (!inputUrl.trim()) {
+      setUrlError(t('form.sources.error.empty', { ns: 'taiwan_record' }))
+      return
+    }
 
-      if (!z.string().url().safeParse(inputUrl).success) {
-        setUrlError(t('form.sources.error.invalid', { ns: 'taiwan_record' }))
-        return
-      }
+    if (!z.string().url().safeParse(inputUrl).success) {
+      setUrlError(t('form.sources.error.invalid', { ns: 'taiwan_record' }))
+      return
+    }
 
-      if (currentSources.includes(inputUrl)) {
-        setUrlError(t('form.sources.error.duplicate', { ns: 'taiwan_record' }))
-        return
-      }
+    if (sources?.includes(inputUrl)) {
+      setUrlError(t('form.sources.error.duplicate', { ns: 'taiwan_record' }))
+      return
+    }
 
-      if (currentSources.length >= maxSources) {
-        setUrlError(
-          t('form.sources.error.maxReached', {
-            max: maxSources,
-            ns: 'taiwan_record',
-          })
-        )
-        return
-      }
-
-      setInputUrl('')
-      return [...currentSources, inputUrl]
-    },
-    [inputUrl, maxSources, t]
-  )
+    setInputUrl('')
+    return inputUrl
+  }, [inputUrl, t, sources])
 
   const handleRemoveSource = useCallback(
     (currentSources: string[], index: number) => {
@@ -69,30 +50,14 @@ const TaiwanRecordSourceManager = memo(function TaiwanRecordSourceManager(
     []
   )
 
-  const canAddMore = (sources: string[]) => sources.length < maxSources
-
   return (
     <Controller
       control={control}
-      name={fieldName}
+      name="sources"
       render={({ field }) => (
         <Box>
           <Typography variant="body2" fontWeight={600} mb={1}>
             {t('form.sources.label', { ns: 'taiwan_record' })}
-            {!canAddMore((field.value as string[]) || []) && (
-              <Typography
-                component="span"
-                variant="caption"
-                sx={{ ml: 1, color: 'text.secondary' }}
-              >
-                (
-                {t('form.sources.maxReached', {
-                  max: maxSources,
-                  ns: 'taiwan_record',
-                })}
-                )
-              </Typography>
-            )}
           </Typography>
 
           <Stack gap={2}>
@@ -109,15 +74,14 @@ const TaiwanRecordSourceManager = memo(function TaiwanRecordSourceManager(
                   setInputUrl(e.target.value)
                   setUrlError('')
                 }}
-                onKeyPress={(e) => {
+                onKeyUp={(e) => {
+                  if (!field.value) return
                   if (e.key === 'Enter') {
-                    const newSources = handleAddSource(field.value as string[])
-                    if (newSources) {
-                      field.onChange(newSources)
-                    }
+                    const newSource = handleAddSource()
+                    if (!newSource) return
+                    field.onChange([...(field.value || []), newSource])
                   }
                 }}
-                disabled={!canAddMore((field.value as string[]) || [])}
                 error={!!urlError}
                 helperText={urlError}
                 color="info"
@@ -125,12 +89,11 @@ const TaiwanRecordSourceManager = memo(function TaiwanRecordSourceManager(
               <Button
                 variant="contained"
                 size="small"
-                disabled={!canAddMore((field.value as string[]) || [])}
                 onClick={() => {
-                  const newSources = handleAddSource(field.value as string[])
-                  if (newSources) {
-                    field.onChange(newSources)
-                  }
+                  if (!field.value) return
+                  const newSource = handleAddSource()
+                  if (!newSource) return
+                  field.onChange([...(field.value || []), newSource])
                 }}
                 sx={{ textTransform: 'none', minWidth: 'fit-content' }}
                 color="info"
@@ -141,25 +104,23 @@ const TaiwanRecordSourceManager = memo(function TaiwanRecordSourceManager(
             </Stack>
 
             {/* 已登錄的連結列表 */}
-            {(field.value as string[])?.length > 0 && (
+            {field.value && field.value.length > 0 && (
               <Stack gap={1}>
                 <Typography variant="caption" sx={{ color: 'text.secondary' }}>
                   {t('form.sources.count', {
-                    current: (field.value as string[]).length,
-                    max: maxSources,
+                    current: field.value.length,
                     ns: 'taiwan_record',
                   })}
                 </Typography>
                 <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1 }}>
-                  {(field.value as string[]).map((source, index) => (
+                  {field.value.map((source, index) => (
                     <Chip
                       key={index}
                       icon={<LinkIcon />}
                       label={source}
                       onDelete={() => {
-                        field.onChange(
-                          handleRemoveSource(field.value as string[], index)
-                        )
+                        if (!field.value) return
+                        field.onChange(handleRemoveSource(field.value, index))
                       }}
                       variant="outlined"
                       size="small"

--- a/src/modules/TaiwanRecord/components/TaiwanRecordSourceManager.tsx
+++ b/src/modules/TaiwanRecord/components/TaiwanRecordSourceManager.tsx
@@ -1,0 +1,187 @@
+import { memo, useCallback, useState } from 'react'
+import { Controller, FieldPath, Control } from 'react-hook-form'
+import { Box, Button, Chip, Stack, TextField, Typography } from '@mui/material'
+import AddIcon from '@mui/icons-material/Add'
+import LinkIcon from '@mui/icons-material/Link'
+import {
+  TaiwanRecordCreateInput,
+  TaiwanRecordUpdateInput,
+  LENGTH_CONSTRAINTS,
+} from '@/modules/TaiwanRecord/business/TaiwanRecord'
+import useTranslationClient from '@/common/lib/i18n/hooks/useTranslationClient'
+import { z } from 'zod'
+
+interface TaiwanRecordSourceManagerProps {
+  control: Control<TaiwanRecordCreateInput | TaiwanRecordUpdateInput>
+  fieldName: FieldPath<TaiwanRecordCreateInput | TaiwanRecordUpdateInput>
+}
+
+const TaiwanRecordSourceManager = memo(function TaiwanRecordSourceManager(
+  props: TaiwanRecordSourceManagerProps
+) {
+  const { control, fieldName } = props
+  const { t } = useTranslationClient(['taiwan_record'])
+  const [inputUrl, setInputUrl] = useState('')
+  const [urlError, setUrlError] = useState('')
+
+  const maxSources = LENGTH_CONSTRAINTS.sources
+
+  const handleAddSource = useCallback(
+    (currentSources: string[]) => {
+      setUrlError('')
+
+      if (!inputUrl.trim()) {
+        setUrlError(t('form.sources.error.empty', { ns: 'taiwan_record' }))
+        return
+      }
+
+      if (!z.string().url().safeParse(inputUrl).success) {
+        setUrlError(t('form.sources.error.invalid', { ns: 'taiwan_record' }))
+        return
+      }
+
+      if (currentSources.includes(inputUrl)) {
+        setUrlError(t('form.sources.error.duplicate', { ns: 'taiwan_record' }))
+        return
+      }
+
+      if (currentSources.length >= maxSources) {
+        setUrlError(
+          t('form.sources.error.maxReached', {
+            max: maxSources,
+            ns: 'taiwan_record',
+          })
+        )
+        return
+      }
+
+      setInputUrl('')
+      return [...currentSources, inputUrl]
+    },
+    [inputUrl, maxSources, t]
+  )
+
+  const handleRemoveSource = useCallback(
+    (currentSources: string[], index: number) => {
+      setUrlError('')
+      return currentSources.filter((_, i) => i !== index)
+    },
+    []
+  )
+
+  const canAddMore = (sources: string[]) => sources.length < maxSources
+
+  return (
+    <Controller
+      control={control}
+      name={fieldName}
+      render={({ field }) => (
+        <Box>
+          <Typography variant="body2" fontWeight={600} mb={1}>
+            {t('form.sources.label', { ns: 'taiwan_record' })}
+            {!canAddMore((field.value as string[]) || []) && (
+              <Typography
+                component="span"
+                variant="caption"
+                sx={{ ml: 1, color: 'text.secondary' }}
+              >
+                (
+                {t('form.sources.maxReached', {
+                  max: maxSources,
+                  ns: 'taiwan_record',
+                })}
+                )
+              </Typography>
+            )}
+          </Typography>
+
+          <Stack gap={2}>
+            {/* 輸入框和新增按鈕 */}
+            <Stack direction="row" gap={1}>
+              <TextField
+                size="small"
+                fullWidth
+                placeholder={t('form.sources.input.placeholder', {
+                  ns: 'taiwan_record',
+                })}
+                value={inputUrl}
+                onChange={(e) => {
+                  setInputUrl(e.target.value)
+                  setUrlError('')
+                }}
+                onKeyPress={(e) => {
+                  if (e.key === 'Enter') {
+                    const newSources = handleAddSource(field.value as string[])
+                    if (newSources) {
+                      field.onChange(newSources)
+                    }
+                  }
+                }}
+                disabled={!canAddMore((field.value as string[]) || [])}
+                error={!!urlError}
+                helperText={urlError}
+                color="info"
+              />
+              <Button
+                variant="contained"
+                size="small"
+                disabled={!canAddMore((field.value as string[]) || [])}
+                onClick={() => {
+                  const newSources = handleAddSource(field.value as string[])
+                  if (newSources) {
+                    field.onChange(newSources)
+                  }
+                }}
+                sx={{ textTransform: 'none', minWidth: 'fit-content' }}
+                color="info"
+              >
+                <AddIcon sx={{ mr: 0.5 }} fontSize="small" />
+                {t('form.sources.add.btn', { ns: 'taiwan_record' })}
+              </Button>
+            </Stack>
+
+            {/* 已登錄的連結列表 */}
+            {(field.value as string[])?.length > 0 && (
+              <Stack gap={1}>
+                <Typography variant="caption" sx={{ color: 'text.secondary' }}>
+                  {t('form.sources.count', {
+                    current: (field.value as string[]).length,
+                    max: maxSources,
+                    ns: 'taiwan_record',
+                  })}
+                </Typography>
+                <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1 }}>
+                  {(field.value as string[]).map((source, index) => (
+                    <Chip
+                      key={index}
+                      icon={<LinkIcon />}
+                      label={source}
+                      onDelete={() => {
+                        field.onChange(
+                          handleRemoveSource(field.value as string[], index)
+                        )
+                      }}
+                      variant="outlined"
+                      size="small"
+                      sx={{
+                        maxWidth: '100%',
+                        '& .MuiChip-label': {
+                          overflow: 'hidden',
+                          textOverflow: 'ellipsis',
+                          whiteSpace: 'nowrap',
+                          maxWidth: '200px',
+                        },
+                      }}
+                    />
+                  ))}
+                </Box>
+              </Stack>
+            )}
+          </Stack>
+        </Box>
+      )}
+    />
+  )
+})
+
+export default TaiwanRecordSourceManager

--- a/src/modules/TaiwanRecord/components/TaiwanRecordSources.tsx
+++ b/src/modules/TaiwanRecord/components/TaiwanRecordSources.tsx
@@ -1,6 +1,5 @@
 import UContentCard from '@/common/components/atoms/UContentCard'
 import UContentCardDialog from '@/common/components/atoms/UContentCardDialog'
-import { Sources } from '@/modules/TaiwanRecord/business/TaiwanRecord'
 import Avatar from '@mui/material/Avatar'
 import AvatarGroup from '@mui/material/AvatarGroup'
 import Box from '@mui/material/Box'
@@ -156,7 +155,7 @@ const SourcesDialog = memo(function SourcesDialog(props: SourcesDialogProps) {
 const MAX_FAVICON_AVATAR_COUNT = 4
 
 interface TaiwanRecordSourcesProps {
-  sources: Sources
+  sources: string[]
 }
 
 const TaiwanRecordSources = ({ sources }: TaiwanRecordSourcesProps) => {
@@ -167,7 +166,7 @@ const TaiwanRecordSources = ({ sources }: TaiwanRecordSourcesProps) => {
 
   useEffect(() => {
     const fetchSourceMetadatas = async () => {
-      const sourceMetadatas = await Promise.all(sources.links.map(getMetadata))
+      const sourceMetadatas = await Promise.all(sources.map(getMetadata))
       setSourceMetadatas(sourceMetadatas)
     }
     fetchSourceMetadatas()
@@ -212,7 +211,7 @@ const TaiwanRecordSources = ({ sources }: TaiwanRecordSourcesProps) => {
                 height: 16,
               }}
               key={index}
-              alt={new URL(sources.links[index]).hostname}
+              alt={new URL(sources[index]).hostname}
               src={m.favicon}
             >
               <LinkIcon sx={{ width: 12, height: 12 }} />

--- a/src/modules/TaiwanRecord/hooks/useTaiwanRecordForm.ts
+++ b/src/modules/TaiwanRecord/hooks/useTaiwanRecordForm.ts
@@ -1,0 +1,61 @@
+import { useForm } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { useCallback, useEffect, useMemo } from 'react'
+import {
+  defaultTaiwanRecordCreate,
+  TaiwanRecordCreateInput,
+  TaiwanRecordCreateOutput,
+  TaiwanRecordUpdateInput,
+  TaiwanRecordUpdateOutput,
+  taiwanRecordUpdateSchema,
+  taiwanRecordCreateSchema,
+  defaultTaiwanRecordUpdate,
+  TaiwanRecord,
+} from '@/modules/TaiwanRecord/business/TaiwanRecord'
+
+export type TaiwanRecordFormMode = 'create' | 'update'
+
+type UseTaiwanRecordFormProps = {
+  mode: TaiwanRecordFormMode
+  record?: TaiwanRecord
+}
+
+export default function useTaiwanRecordForm(props: UseTaiwanRecordFormProps) {
+  const { mode, record } = props
+
+  const defaultValues = useMemo(() => {
+    if (mode === 'update' && record) {
+      return record
+    }
+    return mode === 'create'
+      ? defaultTaiwanRecordCreate
+      : defaultTaiwanRecordUpdate
+  }, [mode, record])
+
+  const form = useForm<TaiwanRecordCreateInput | TaiwanRecordUpdateInput>({
+    resolver: zodResolver(
+      mode === 'create' ? taiwanRecordCreateSchema : taiwanRecordUpdateSchema
+    ),
+    mode: 'onSubmit',
+    defaultValues,
+  })
+
+  const handleReset = useCallback(() => {
+    form.reset(defaultValues)
+  }, [form, defaultValues])
+
+  // 表單預設值變化時，更新表單，保持最新狀態
+  useEffect(() => {
+    form.reset(defaultValues)
+  }, [form, defaultValues])
+
+  const handleSubmit = useCallback(
+    async (value: TaiwanRecordCreateOutput | TaiwanRecordUpdateOutput) => {
+      console.log(value)
+      // TODO: 呼教 API 新增/更新 Taiwan Record
+    },
+    []
+  )
+
+  return { form, handleReset, handleSubmit }
+}


### PR DESCRIPTION
## Summary

- Taiwan record dialog for both `create`/`update` modes

## Test Plan

<img width="678" height="1003" alt="CleanShot 2025-12-04 at 12 52 47" src="https://github.com/user-attachments/assets/c01f9d3b-7cff-405e-8bcb-4fb10fc3a6c4" />


<img width="439" height="872" alt="CleanShot 2025-12-04 at 12 52 57" src="https://github.com/user-attachments/assets/40317f93-6c7d-4955-8b5a-076f7ce70fc8" />

## Task
