### PR TITLE
feat: Open update taiwan record dialog after click account taiwan record item title

### DIFF
--- a/src/modules/Account/TaiwanRecord/components/AccountTaiwanRecordList.tsx
+++ b/src/modules/Account/TaiwanRecord/components/AccountTaiwanRecordList.tsx
@@ -5,11 +5,12 @@ import UHStack from '@/common/components/atoms/UHStack'
 import useAccountLayout from '@/modules/Account/hooks/useAccountLayout'
 import useTranslationClient from '@/common/lib/i18n/hooks/useTranslationClient'
 import { Box, Stack } from '@mui/material'
-import { memo, useCallback, useEffect } from 'react'
+import { memo, useCallback, useEffect, useState } from 'react'
 import UHeightLimitedText from '@/common/components/atoms/UHeightLimitedText'
 import useAccountTaiwanRecordStore from '@/modules/Account/TaiwanRecord/hooks/useAccountTaiwanRecordStore'
 import useAccountStore from '@/modules/Account/hooks/useAccountStore'
 import { TaiwanRecord } from '@/modules/TaiwanRecord/business/TaiwanRecord'
+import TaiwanRecordDialog from '@/modules/TaiwanRecord/components/TaiwanRecordDialog'
 
 type AccountTaiwanRecordListItemProps = {
   taiwanRecord: TaiwanRecord
@@ -85,9 +86,17 @@ const AccountTaiwanRecordList = memo(function AccountTaiwanRecordList() {
     useAccountTaiwanRecordStore.use.filteredAccountTaiwanRecordList()
   const { isCompactView } = useAccountLayout()
 
+  const [taiwanRecordToUpdate, setTaiwanRecordToUpdate] =
+    useState<TaiwanRecord | null>(null)
+  const [isTaiwanRecordDialogOpen, setIsTaiwanRecordDialogOpen] =
+    useState(false)
   const handleTaiwanRecordClick = useCallback((taiwanRecord: TaiwanRecord) => {
-    // TODO: popup taiwan record dialog
-    console.log(taiwanRecord)
+    setTaiwanRecordToUpdate(taiwanRecord)
+    setIsTaiwanRecordDialogOpen(true)
+  }, [])
+  const handleTaiwanRecordDialogClose = useCallback(() => {
+    setTaiwanRecordToUpdate(null)
+    setIsTaiwanRecordDialogOpen(false)
   }, [])
 
   if (isCompactView) {
@@ -140,6 +149,14 @@ const AccountTaiwanRecordList = memo(function AccountTaiwanRecordList() {
           />
         </Box>
       ))}
+      {taiwanRecordToUpdate && (
+        <TaiwanRecordDialog
+          mode="update"
+          taiwanRecord={taiwanRecordToUpdate}
+          open={isTaiwanRecordDialogOpen}
+          onClose={handleTaiwanRecordDialogClose}
+        />
+      )}
     </Stack>
   )
 })

--- a/src/modules/TaiwanRecord/components/TaiwanRecordDialog.tsx
+++ b/src/modules/TaiwanRecord/components/TaiwanRecordDialog.tsx
@@ -26,17 +26,17 @@ import TaiwanRecordSourceManager from '@/modules/TaiwanRecord/components/TaiwanR
 
 type TaiwanRecordDialogProps = DialogProps & {
   mode: TaiwanRecordFormMode
-  record?: TaiwanRecord
+  taiwanRecord?: TaiwanRecord
 }
 
 export default function TaiwanRecordDialog(props: TaiwanRecordDialogProps) {
-  const { mode, record, ...dialogProps } = props
+  const { mode, taiwanRecord, ...dialogProps } = props
   const { t } = useTranslationClient(['taiwan_record', 'common'])
   const [isSubmitting, setIsSubmitting] = useState(false)
 
   const { form, handleReset, handleSubmit } = useTaiwanRecordForm({
     mode,
-    record,
+    taiwanRecord,
   })
 
   const title = useMemo(() => {

--- a/src/modules/TaiwanRecord/hooks/useTaiwanRecordForm.ts
+++ b/src/modules/TaiwanRecord/hooks/useTaiwanRecordForm.ts
@@ -17,20 +17,20 @@ export type TaiwanRecordFormMode = 'create' | 'update'
 
 type UseTaiwanRecordFormProps = {
   mode: TaiwanRecordFormMode
-  record?: TaiwanRecord
+  taiwanRecord?: TaiwanRecord
 }
 
 export default function useTaiwanRecordForm(props: UseTaiwanRecordFormProps) {
-  const { mode, record } = props
+  const { mode, taiwanRecord } = props
 
   const defaultValues = useMemo(() => {
-    if (mode === 'update' && record) {
-      return record
+    if (mode === 'update' && taiwanRecord) {
+      return taiwanRecord
     }
     return mode === 'create'
       ? defaultTaiwanRecordCreate
       : defaultTaiwanRecordUpdate
-  }, [mode, record])
+  }, [mode, taiwanRecord])
 
   const form = useForm<TaiwanRecordCreateInput | TaiwanRecordUpdateInput>({
     resolver: zodResolver(


### PR DESCRIPTION
## Summary

- Open update taiwan record dialog after click account taiwan record item title

## Test Plan

<img width="795" height="978" alt="CleanShot 2025-12-04 at 13 36 57" src="https://github.com/user-attachments/assets/e4ae765d-ad4c-4a53-8e08-653cde68eb2b" />


## Task

