### PR TITLE
fix: Preserve locale after logon & Taiwan record UI/UX (logon guard/required label/image input blocker) & Account notification style

### DIFF
--- a/src/common/lib/router/helper.ts
+++ b/src/common/lib/router/helper.ts
@@ -60,7 +60,10 @@ export default function resolveRouteUrlHelper(
   }
   return concatPathAndQuery(
     { url, query },
-    { returnAbsoluteUrl: options?.returnAbsoluteUrl }
+    {
+      returnAbsoluteUrl: options?.returnAbsoluteUrl,
+      language: options?.language,
+    }
   )
 }
 

--- a/src/common/lib/router/useURouterClient.ts
+++ b/src/common/lib/router/useURouterClient.ts
@@ -7,6 +7,8 @@ import resolveRouteUrlHelper, {
   concatPathAndQuery,
   ResolveRouteUrlHelperOptions,
 } from '@/common/lib/router/helper'
+import useTranslationClient from '@/common/lib/i18n/hooks/useTranslationClient'
+import { Language } from '@/common/lib/i18n/types'
 
 type ResolveRouteUrlOptions = ResolveRouteUrlHelperOptions & {
   /**
@@ -14,6 +16,11 @@ type ResolveRouteUrlOptions = ResolveRouteUrlHelperOptions & {
    * @default false
    */
   preserveSearchParams?: boolean
+  /**
+   * 是否保留目前語系
+   * @default true
+   */
+  preserveLanguage?: boolean
   /**
    * 既有的 SearchParams 的黑名單，
    * 不會被保留到新的路徑
@@ -26,6 +33,7 @@ type ResolveRouteUrlOptions = ResolveRouteUrlHelperOptions & {
  * 由於 `useSearchParams` 是 client component 的 hook
  */
 export default function useURouterClient() {
+  const { i18n } = useTranslationClient()
   const searchParams = useSearchParams()
 
   /**
@@ -37,8 +45,11 @@ export default function useURouterClient() {
    */
   const resolveRouteUrl = useCallback(
     (route: URoute, options?: ResolveRouteUrlOptions) => {
-      const { preserveSearchParams = false, blackListSearchParams = [] } =
-        options ?? {}
+      const {
+        preserveSearchParams = false,
+        preserveLanguage = true,
+        blackListSearchParams = [],
+      } = options ?? {}
 
       // 將 route 的 query 填入 params
       // 如果需要保留既有的 SearchParams，則複製一份
@@ -58,11 +69,12 @@ export default function useURouterClient() {
 
       const url = resolveRouteUrlHelper(newRoute, {
         returnAbsoluteUrl: options?.returnAbsoluteUrl,
+        language: preserveLanguage ? (i18n.language as Language) : undefined,
       })
 
       return url
     },
-    [searchParams]
+    [searchParams, i18n.language]
   )
 
   return { resolveRouteUrl, concatPathAndQuery }

--- a/src/modules/Account/Notification/components/AccountNotificationSetting.tsx
+++ b/src/modules/Account/Notification/components/AccountNotificationSetting.tsx
@@ -17,26 +17,23 @@ import useAccountLayout from '@/modules/Account/hooks/useAccountLayout'
 
 const AccountFormItem = ({
   label,
-  direction = 'column',
   children,
 }: {
   label: string
-  direction?: 'column' | 'row'
   children: React.ReactNode
 }) => {
   return (
     <Stack
-      direction={direction}
+      direction="row"
       gap={1}
       sx={{
-        alignItems: direction === 'row' ? 'center' : 'flex-start',
-        justifyContent: direction === 'row' ? 'space-between' : 'initial',
+        alignItems: 'center',
       }}
     >
+      {children}
       <Typography variant="body1" fontWeight={600}>
         {label}
       </Typography>
-      {children}
     </Stack>
   )
 }
@@ -88,7 +85,6 @@ const AccountNotificationSetting = memo(function AccountNotificationSetting() {
         label={t('notificationSetting.billRelease.label', {
           ns: 'account',
         })}
-        direction="row"
       >
         <Controller
           control={form.control}
@@ -109,7 +105,6 @@ const AccountNotificationSetting = memo(function AccountNotificationSetting() {
         label={t('notificationSetting.ustwArticleRelease.label', {
           ns: 'account',
         })}
-        direction="row"
       >
         <Controller
           control={form.control}
@@ -130,7 +125,6 @@ const AccountNotificationSetting = memo(function AccountNotificationSetting() {
         label={t('notificationSetting.ketagalanArticleRelease.label', {
           ns: 'account',
         })}
-        direction="row"
       >
         <Controller
           control={form.control}
@@ -151,7 +145,6 @@ const AccountNotificationSetting = memo(function AccountNotificationSetting() {
         label={t('notificationSetting.podcastRelease.label', {
           ns: 'account',
         })}
-        direction="row"
       >
         <Controller
           control={form.control}
@@ -172,7 +165,6 @@ const AccountNotificationSetting = memo(function AccountNotificationSetting() {
         label={t('notificationSetting.subscribedBillUpdate.label', {
           ns: 'account',
         })}
-        direction="row"
       >
         <Controller
           control={form.control}
@@ -193,7 +185,6 @@ const AccountNotificationSetting = memo(function AccountNotificationSetting() {
         label={t('notificationSetting.subscribedPeopleUpdate.label', {
           ns: 'account',
         })}
-        direction="row"
       >
         <Controller
           control={form.control}
@@ -215,7 +206,6 @@ const AccountNotificationSetting = memo(function AccountNotificationSetting() {
         label={t('notificationSetting.newsletter.label', {
           ns: 'account',
         })}
-        direction="row"
       >
         <Controller
           control={form.control}

--- a/src/modules/Auth/providers/UAuthProvider.tsx
+++ b/src/modules/Auth/providers/UAuthProvider.tsx
@@ -35,10 +35,13 @@ export default function UAuthProvider({
   const login = useCallback(
     (options?: { returnTo?: string }) => {
       router.push(
-        resolveRouteUrl({
-          name: RouteName.AuthLogin,
-          query: { returnTo: options?.returnTo ?? null },
-        })
+        resolveRouteUrl(
+          {
+            name: RouteName.AuthLogin,
+            query: { returnTo: options?.returnTo ?? null },
+          },
+          { preserveLanguage: false }
+        )
       )
     },
     [router, resolveRouteUrl]

--- a/src/modules/People/components/PeopleTracker/TaiwanRecordSection.tsx
+++ b/src/modules/People/components/PeopleTracker/TaiwanRecordSection.tsx
@@ -11,7 +11,7 @@ import Stack from '@mui/material/Stack'
 import { People } from '@/modules/People/business/People'
 import useTranslationClient from '@/common/lib/i18n/hooks/useTranslationClient'
 import TaiwanRecordDialog from '@/modules/TaiwanRecord/components/TaiwanRecordDialog'
-import { useState, useMemo } from 'react'
+import { useState, useMemo, useCallback } from 'react'
 import { useQuery } from '@apollo/client'
 import { QUERY_PEOPLE_PUBLISHED_TAIWAN_RECORDS } from '@/modules/TaiwanRecord/graphql/gql'
 import type {
@@ -19,6 +19,10 @@ import type {
   QueryPeoplePublishedTaiwanRecordsQueryVariables,
 } from '@/common/lib/graphql/__generated__/graphql'
 import { TaiwanRecordUtils } from '@/modules/TaiwanRecord/business/TaiwanRecord'
+import useURouterClient from '@/common/lib/router/useURouterClient'
+import { useUAuth } from '@/modules/Auth/providers/UAuthProvider'
+import { useAccount } from '@/modules/Account/providers/AccountProvider'
+import { RouteName } from '@/common/lib/router/routes'
 
 interface TaiwanRecordSectionProps {
   people: People
@@ -48,6 +52,27 @@ export default function TaiwanRecordSection({
       .map((doc) => TaiwanRecordUtils.parse(doc))
   }, [data])
 
+  const { resolveRouteUrl } = useURouterClient()
+  const { login } = useUAuth()
+  const { isAccountLoading, account } = useAccount()
+  const handleSubmitTaiwanRecordClick = useCallback(() => {
+    if (isAccountLoading) return
+
+    if (!account) {
+      login({
+        returnTo: people.id
+          ? resolveRouteUrl({
+              name: RouteName.PeopleDetail,
+              params: { peopleId: people.id },
+            })
+          : resolveRouteUrl({ name: RouteName.Home }),
+      })
+      return
+    }
+
+    setIsCreateDialogOpen(true)
+  }, [isAccountLoading, account, login, resolveRouteUrl, people.id])
+
   return (
     <LandingSectionWrapper backgroundColor={theme.color.neutral[200]}>
       <Stack gap={theme.spacing(7.5)}>
@@ -60,7 +85,7 @@ export default function TaiwanRecordSection({
               rounded
               size="medium"
               startIcon={<AddIcon />}
-              onClick={() => setIsCreateDialogOpen(true)}
+              onClick={handleSubmitTaiwanRecordClick}
             >
               {t('page.section.taiwanRecord.submit.btn', { ns: 'people' })}
             </UButton>

--- a/src/modules/TaiwanRecord/components/TaiwanRecordDialog.tsx
+++ b/src/modules/TaiwanRecord/components/TaiwanRecordDialog.tsx
@@ -191,7 +191,10 @@ export default function TaiwanRecordDialog(props: TaiwanRecordDialogProps) {
                 render={({ field, fieldState: { error } }) => (
                   <Box>
                     <Typography variant="body2" fontWeight={600} mb={1}>
-                      {t('form.title.label', { ns: 'taiwan_record' })}
+                      {t('form.title.label', { ns: 'taiwan_record' })}{' '}
+                      <Box component="span" color="error.main">
+                        *
+                      </Box>
                     </Typography>
                     <TextField
                       {...field}
@@ -224,7 +227,10 @@ export default function TaiwanRecordDialog(props: TaiwanRecordDialogProps) {
                 render={({ field, fieldState: { error } }) => (
                   <Box>
                     <Typography variant="body2" fontWeight={600} mb={1}>
-                      {t('form.content.label', { ns: 'taiwan_record' })}
+                      {t('form.content.label', { ns: 'taiwan_record' })}{' '}
+                      <Box component="span" color="error.main">
+                        *
+                      </Box>
                     </Typography>
                     <TextField
                       {...field}

--- a/src/modules/TaiwanRecord/components/TaiwanRecordImageUpload.tsx
+++ b/src/modules/TaiwanRecord/components/TaiwanRecordImageUpload.tsx
@@ -182,6 +182,7 @@ const TaiwanRecordImageUpload = memo(function TaiwanRecordImageUpload({
                   }}
                   style={{ display: 'none' }}
                   id="image-upload-input"
+                  disabled={!canAddMore}
                 />
                 <label htmlFor="image-upload-input" style={{ width: '100%' }}>
                   <Button


### PR DESCRIPTION
## Summary

- Preserve locale after logon 
- Taiwan record UI/UX (logon guard/required label/image input blocker) 
- Account notification style

## Test Plan

附上你修改後怎麼測試他，跟測試的結果

## Task

如果這隻 PR 是為了修某個 ticket, 把 link 貼在這